### PR TITLE
Enforce required dropdown with blank option

### DIFF
--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -129,14 +129,6 @@
       }
     };
 
-    //Custom functions to define whether a field is required or not.
-    var valueRequiredMap = {
-      "dropdown": function dropdownRequiredFunction(fieldDef) {
-        //A dropdown field is only required if the blank option is not set
-        return fieldDef && fieldDef.fieldOptions && fieldDef.fieldOptions.definition && fieldDef.fieldOptions.definition.include_blank_option;
-      }
-    };
-
     var fieldValueComparison = {
       "text": function(fieldValue, testValue, condition) {
         return this.comparisonString(fieldValue, testValue, condition);
@@ -351,7 +343,7 @@
               field: field,
               submitted: false,
               validated: false,
-              valueRequired: !(valueRequiredMap[field.type] && valueRequiredMap[field.type](field))
+              valueRequired: field.required
             };
           }
 
@@ -1026,9 +1018,10 @@
         return cb();
       }
 
-      //If the option is empty and a blank option is allowed, then that is also valid.
-      if (found === "" && fieldDefinition.fieldOptions.definition.include_blank_option) {
-        return cb();
+      //If the option is empty and the field is required, then the blank option is being submitted
+      //The blank option is not valid for a required field.
+      if (found === "" && fieldDefinition.required && fieldDefinition.fieldOptions.definition.include_blank_option) {
+        return cb(new Error("The Blank Option is not valid. Please select a value."));
       } else {
         //Otherwise, it is an invalid option
         return cb(new Error("Invalid option specified: " + fieldValue));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-forms
 sonar.projectName=fh-forms-nightly-master
-sonar.projectVersion=1.10.9
+sonar.projectVersion=1.11.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/rulesEngine/test_dropdownBlankOption.js
+++ b/test/unit/rulesEngine/test_dropdownBlankOption.js
@@ -8,7 +8,7 @@ var formsRulesEngine = require('../../../lib/common/forms-rule-engine.js');
  * @param  {boolean} include_blank_option Expecting whether the blank option should available or not
  * @return {object}                      Full form JSON definition
  */
-function getMockDropdownForm(include_blank_option) {
+function getMockDropdownForm(include_blank_option, required) {
   return {
     "_id": "57287eb49b71a8c37fda4849",
     "name": "Test Dropdown Form",
@@ -17,7 +17,7 @@ function getMockDropdownForm(include_blank_option) {
     "pages": [{
       "_id": "57287eb49b71a8c37fda4848",
       "fields": [{
-        "required": true,
+        "required": required,
         "type": "dropdown",
         "name": "Dropdown",
         "fieldCode": null,
@@ -140,7 +140,7 @@ describe("Dropdown Field", function() {
 
   describe('Blank Option', function() {
 
-    it("Blank Option Enabled: Supplying an empty string is valid", function(done) {
+    it("Blank Option Enabled: Supplying an empty string is not valid for a required field", function(done) {
       var formFields = [
         {
           fieldId: dropdownFieldId,
@@ -150,7 +150,28 @@ describe("Dropdown Field", function() {
         }
       ];
 
-      var mockForm = getMockDropdownForm(true);
+      var mockForm = getMockDropdownForm(true, true);
+      var mockSubmission = getMockSubmission(formFields);
+      var engine = formsRulesEngine(mockForm);
+
+      engine.validateForm(mockSubmission, function(err, result) {
+        assert.ok(!err, "Expected no error ");
+        assert.ok(!result.validation.valid, "Expected The Submission To Be Invalid " + JSON.stringify(result));
+        done();
+      });
+    });
+
+    it("Blank Option Enabled: Supplying an empty string is valid for a non-required field", function(done) {
+      var formFields = [
+        {
+          fieldId: dropdownFieldId,
+          fieldValues:[
+            ""
+          ]
+        }
+      ];
+
+      var mockForm = getMockDropdownForm(true, false);
       var mockSubmission = getMockSubmission(formFields);
       var engine = formsRulesEngine(mockForm);
 
@@ -161,7 +182,7 @@ describe("Dropdown Field", function() {
       });
     });
 
-    it("Blank Option Enabled: Supplying no value is valid", function(done) {
+    it("Blank Option Enabled: Supplying no value is not valid for a required field", function(done) {
       var formFields = [
         {
           fieldId: dropdownFieldId,
@@ -169,22 +190,37 @@ describe("Dropdown Field", function() {
         }
       ];
 
-      var mockForm = getMockDropdownForm(true);
+      var mockForm = getMockDropdownForm(true, true);
       var mockSubmission = getMockSubmission(formFields);
 
       var engine = formsRulesEngine(mockForm);
       engine.validateForm(mockSubmission, function(err, result) {
         assert.ok(!err, "Expected no error ");
-        assert.ok(result.validation.valid, "Expected The Submission To Be Valid " + JSON.stringify(result));
+        assert.ok(!result.validation.valid, "Expected The Submission To Be Invalid " + JSON.stringify(result));
         done();
       });
     });
 
-    it("Blank Option Enabled: Supplying no field is valid", function(done) {
+    it("Blank Option Enabled: Supplying no field is not valid for a required field", function(done) {
       var formFields = [
       ];
 
-      var mockForm = getMockDropdownForm(true);
+      var mockForm = getMockDropdownForm(true, true);
+      var mockSubmission = getMockSubmission(formFields);
+
+      var engine = formsRulesEngine(mockForm);
+      engine.validateForm(mockSubmission, function(err, result) {
+        assert.ok(!err, "Expected no error ");
+        assert.ok(!result.validation.valid, "Expected The Submission To Be Invalid " + JSON.stringify(result));
+        done();
+      });
+    });
+
+    it("Blank Option Enabled: Supplying no field is valid for a non-required field", function(done) {
+      var formFields = [
+      ];
+
+      var mockForm = getMockDropdownForm(true, false);
       var mockSubmission = getMockSubmission(formFields);
 
       var engine = formsRulesEngine(mockForm);
@@ -205,7 +241,7 @@ describe("Dropdown Field", function() {
         }
       ];
 
-      var mockForm = getMockDropdownForm(false);
+      var mockForm = getMockDropdownForm(false, true);
       var mockSubmission = getMockSubmission(formFields);
 
       var engine = formsRulesEngine(mockForm);
@@ -224,7 +260,7 @@ describe("Dropdown Field", function() {
         }
       ];
 
-      var mockForm = getMockDropdownForm(false);
+      var mockForm = getMockDropdownForm(false, true);
       var mockSubmission = getMockSubmission(formFields);
 
       var engine = formsRulesEngine(mockForm);


### PR DESCRIPTION
# Motivation

When a dropdown field has the blank option and is required, then it still should require that a value is submitted with the dropdown.

# Changes

Updated the rules engine to enforce dropdown values if the field is required.