### PR TITLE
Switching fh-forms to using a single mongoose and database connection pool (WIP DO NOT MERGE)

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -11,55 +11,136 @@ var deleteAppReferences = require('./impl/deleteAppRefrences.js');
 var dataSourceImpl = require('./impl/dataSources');
 var dataTargetImpl = require('./impl/dataTargets');
 var config = require('./config');
+var mongoUriParser = require('mongodb-uri');
 var logger = logfns.getLogger();
+var async = require('async');
+
+//Single mongoose connection for forms.
+var mongooseConnection;
+var dbConnection;
+
+//TODO: This should be global.
+mongoose.Promise = global.Promise;
+
+
+function getMongooseConnection(uri, connections, cb) {
+  //Already have a mongoose connection, going to re-use the connection pool to switch to the required database.
+  var parsedMongoUri = mongoUriParser.parse(uri);
+
+  parsedMongoUri.options = parsedMongoUri.options || {};
+
+  //TODO: This can be configured.
+  parsedMongoUri.options.poolSize = 5;
+
+  var newUrl = mongoUriParser.format(parsedMongoUri);
+
+  //If there is no mongoose connection, then create one at least.
+  if (!mongooseConnection) {
+    logger.debug("No Mongoose Connection, creating one.");
+    mongooseConnection = mongoose.createConnection(newUrl);
+  }
+
+  //There is already a mongoose connection, can already use this.
+  if (connections.mongooseConnection) {
+    logger.debug("Using cached mongoose Db connection");
+    return cb(undefined, connections.mongooseConnection);
+  }
+
+  var dbName = parsedMongoUri.database;
+
+  //Already have a mongoose connection, need to get a handle to the other database.
+  var mongooseDbConnection = mongooseConnection.useDb(dbName);
+
+  logger.debug("Mongoose connected to new db");
+  //Authenticating to the database
+
+  connections.mongooseConnection = mongooseDbConnection;
+
+  //Db is authenticated, can now do stuff.
+  return cb(undefined, mongooseDbConnection);
+}
 
 
 var forms = {
   connections: {},
   setConfig: config.set,
 
-  initConnection : function(options, cb) {
+  initConnection : function(options, callback) {
     var self = this;
     var uri = options.uri;
     var key = options.key || uri;
     var config = options.config || {};
-    if ( self.connections[key] ) {
-      return cb(undefined, self.connections[key]);
-    }
-    var paramValidation = validate(options);
 
-    logger.info("Initialising mongo connections");
 
-    function handleConnectionResponse(err, databaseConn) {
-      if (err) {
-        logger.error("Error connecting to mongo using client", err);
-        return cb(err);
+    //If there is already a mongoose connection, we can use the shared pool to connect to it.
+    //Prevents having too many mongo connections open.
+
+    async.waterfall([
+      function validateParams(cb) {
+        logger.debug("Validate Params Start", options);
+        var paramValidation = validate(options);
+
+        paramValidation.has("uri", function(failed) {
+          if (failed) {
+            return cb(new Error("Invalid Params: " + JSON.stringify(failed)));
+          }
+
+          logger.debug("Valid Params");
+
+          return cb();
+        });
+      },
+      //First getting a mongoose db connection.
+      function getMongooseConnectionDb(cb) {
+
+        logger.debug("Getting Mongoose Connection");
+        self.connections[key] = self.connections[key] || {};
+        getMongooseConnection(uri, self.connections[key], cb);
+      },
+      //Getting a mongo db connection (for gridfs file operations)
+      function getDbConnection(mongooseConnection, cb) {
+        logger.debug("Got Mongoose Connection. Getting DB Connection for GridFS");
+
+
+        //If there is already a database connection for this key, don't try and connect again.
+        if (self.connections[key] && self.connections[key].databaseConnection) {
+          return cb(undefined, self.connections[key]);
+        }
+
+        //TODO: Clean this.
+        function handleConnectionResponse(err, databaseConn) {
+          if (err) {
+            logger.error("Error connecting to mongo using client", err);
+            return cb(err);
+          }
+
+          //Assigning the global db connection
+          dbConnection = dbConnection ? dbConnection : databaseConn;
+
+
+          //Switch to the correct Database
+          var parsedMongoUri = mongoUriParser.parse(uri);
+
+          var dbName = parsedMongoUri.database;
+
+          self.connections[key].databaseConnection = dbConnection.db(dbName);
+
+          logger.info("Connected to mongo, initialising models");
+
+          models.init(self.connections[key].mongooseConnection, config); //Initialise the models on the created mongoose connection.
+
+          return cb(undefined, self.connections[key]); //Successful completion of connection, no error returned.
+        }
+
+        if (!dbConnection) {
+          //Ensuring that the mongoClient call is bound to the namespace to ensure the request ID is specified if there is an error.
+          return MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(handleConnectionResponse) : handleConnectionResponse);
+        } else {
+          logger.ensureRequestId ? logger.ensureRequestId(handleConnectionResponse)(undefined, dbConnection) : handleConnectionResponse(undefined, dbConnection);
+        }
+
       }
-
-      logger.info("Connected to mongo");
-
-      mongoose.Promise = global.Promise;
-      var connections =  {
-        "databaseConnection": databaseConn,
-        "mongooseConnection": mongoose.createConnection(uri)
-      };
-
-      self.connections[key] = connections;
-
-
-      models.init(connections.mongooseConnection, config); //Initialise the models on the created mongoose connection.
-
-      return cb(undefined, connections); //Successful completion of connection, no error returned.
-    }
-
-    paramValidation.has("uri", function(failed) {
-      if (failed) {
-        return cb(new Error("Invalid Params: " + JSON.stringify(failed)));
-      }
-
-      //Ensuring that the mongoClient call is bound to the namespace to ensure the request ID is specified if there is an error.
-      MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(handleConnectionResponse) : handleConnectionResponse);
-    });
+    ], callback);
   },
 
   tearDownConnection : function(options, cb) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mmmagic": "^0.4.1",
     "moment": "2.14.1",
     "mongodb": "2.1.18",
+    "mongodb-uri": "^0.9.7",
     "mongoose": "4.5.0",
     "mongoose-paginate": "5.0.3",
     "phantom": "2.1.21",


### PR DESCRIPTION
# Motivation

This is an example of how to use a single mongoose and mongodb connection pool to service requests to connect to different databases for data.

This allows more control over the number of connections that are made to mongo.