### PR TITLE
Added separate function to generate email data for submission

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -437,6 +437,18 @@ var forms = {
     });
   },
 
+  getSubmissionEmailData: function(options, params, cb) {
+    var self = this;
+
+    self.initConnection(options, function(err, connections) {
+      if (err) {
+        return cb(err);
+      }
+
+      return require('./impl/getSubmissionEmailData.js')(connections, options, params, cb);
+    });
+  },
+
   generateSubmissionPdf: function(options, cb) {
     var self = this;
 

--- a/lib/impl/getSubmissionEmailData.js
+++ b/lib/impl/getSubmissionEmailData.js
@@ -1,0 +1,36 @@
+var getSubmission = require('./getSubmission');
+var notifications = require('./notification');
+
+/**
+ *
+ *
+ * Function to get a single submission in email format.
+ *
+ *
+ * Used to be able to send email notifications when submissions have completed.
+ *
+ *
+ * @param connections
+ * @param options
+ * @param params
+ * @param cb
+ */
+module.exports = function getSubmissionEmailData(connections, options, params, cb) {
+
+  //Getting the full submission definition.
+  getSubmission(connections, options, params, function(err, fullSubmission) {
+    if (err) {
+      return cb(err);
+    }
+
+    //Building the data required for the email
+    notifications.buildNotificationParams(connections, {
+      formSubmission: fullSubmission
+    }, function(err, notificationMessage) {
+      return cb(err, {
+        formSubmission: fullSubmission,
+        notificationMessage: notificationMessage
+      });
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {

--- a/test/unit/impl/test_getSubmissionEmailData.js
+++ b/test/unit/impl/test_getSubmissionEmailData.js
@@ -1,0 +1,62 @@
+var sinon = require('sinon');
+var _ = require('underscore');
+var proxyquire = require('proxyquire');
+var assert = require('assert');
+
+describe("Building Submission Email Data", function() {
+  var mockSubmission = require('../../Fixtures/mockSubmissions').complexSubmission1;
+  var mockNotificationMessage = {
+    submittedFields: []
+  };
+
+  beforeEach(function() {
+    this.getSubmissionStub = sinon.stub().callsArgWith(3, undefined, mockSubmission);
+    this.buildNotificationParamsStub = sinon.stub().callsArgWith(2, undefined, mockNotificationMessage);
+
+    var mocks = {
+      './getSubmission': this.getSubmissionStub,
+      './notification': {
+        buildNotificationParams: this.buildNotificationParamsStub
+      }
+    };
+    this.getSubmissionEmailData = proxyquire('../../../lib/impl/getSubmissionEmailData', mocks);
+  });
+
+
+
+  it("It should get a submission and build the email data.", function(done) {
+    var self = this;
+
+    var mockConnections = {
+      mongooseConnection: {
+
+      },
+      databaseConnection: {
+
+      }
+    };
+
+    var mockParams = {
+      _id: "mocksubmissionid"
+    };
+
+    var mockConnectionParams = {
+      uri: "mongodb://test.url/database"
+    };
+
+    this.getSubmissionEmailData(mockConnections, mockConnectionParams, mockParams, function(err, messageDetails) {
+      assert.ok(!err, "Expected no error");
+
+      assert.equal(mockSubmission, messageDetails.formSubmission, "Expected the full submission in the response object");
+      assert.equal(mockNotificationMessage, messageDetails.notificationMessage, "Expected the email notification in the response object");
+
+      sinon.assert.calledOnce(self.getSubmissionStub);
+      sinon.assert.calledWith(self.getSubmissionStub, sinon.match(mockConnections), sinon.match(mockConnectionParams), sinon.match(mockParams), sinon.match.func);
+
+      sinon.assert.calledOnce(self.buildNotificationParamsStub);
+      sinon.assert.calledWith(self.buildNotificationParamsStub, sinon.match(mockConnections), sinon.match({formSubmission: sinon.match(mockSubmission)}), sinon.match.func);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

The forms API should have a separate function to generate email data for a single submission. This is used to allow sending submission emails using the current templates.

This will prevent other submission processes from interfering with the submission data to be processed.

# Changes

Added a new function `getSubmissionEmailData` to get a single submission and process it to get the email data.