### PR TITLE
Rhmap 11889 shared mongo connections

### DIFF
--- a/fhforms.js
+++ b/fhforms.js
@@ -20,7 +20,10 @@ module.exports.init = function setFormsLogger(logger) {
   }
 
   //Want the logger to be set before doing any requires as there are logger.getLogger statements at the top.
+  module.exports.setupSharedMongoConnections = require('./lib/shared-mongo-connections');
   module.exports.core = require('./lib/forms.js');
   module.exports.middleware = require('./lib/middleware.js');
 };
 module.exports.CONSTANTS = require('./lib/common/constants');
+
+

--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -816,10 +816,8 @@
               return cb(undefined, "Expected max of " + fieldDefinition.fieldOptions.definition.maxRepeat + " values for field " + fieldDefinition.name + " but got " + numSubmittedValues);
             }
           }
-        } else {
-          if (numSubmittedValues > 1) {
-            return cb(undefined, "Should not have multiple values for non-repeating field");
-          }
+        } else if (numSubmittedValues > 1) {
+          return cb(undefined, "Should not have multiple values for non-repeating field");
         }
 
         return cb(undefined, null);
@@ -1132,13 +1130,11 @@
         } else {
           return cb(new Error("Invalid object for latitude longitude submission"));
         }
-      } else {
-        if (fieldValue.zone && fieldValue.eastings && fieldValue.northings) {
+      } else if (fieldValue.zone && fieldValue.eastings && fieldValue.northings) {
           //Zone must be 3 characters, eastings 6 and northings 9
-          return validateNorthingsEastings(fieldValue, cb);
-        } else {
-          return cb(new Error("Invalid object for northings easting submission. Zone, Eastings and Northings elements are required"));
-        }
+        return validateNorthingsEastings(fieldValue, cb);
+      } else {
+        return cb(new Error("Invalid object for northings easting submission. Zone, Eastings and Northings elements are required"));
       }
 
       function validateNorthingsEastings(fieldValue, cb) {

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -1,9 +1,7 @@
 var mongoose = require('mongoose');
 var _ = require('underscore');
 var async = require('async');
-var mongoUriParser = require('mongodb-uri');
 var models = require('../lib/common/models.js')();
-var MongoClient = require('mongodb').MongoClient;
 var validate = require('./common/validate.js');
 var getForms = require('./impl/getForms.js')();
 var groups = require('./impl/groups.js');
@@ -14,61 +12,7 @@ var dataSourceImpl = require('./impl/dataSources');
 var dataTargetImpl = require('./impl/dataTargets');
 var config = require('./config');
 var logger = logfns.getLogger();
-
-function getDbName(uri) {
-  var parsedMongooseUri = mongoUriParser.parse(uri);
-  var dbName = parsedMongooseUri.database;
-  return dbName;
-}
-
-/**
- * Get a new mongoose connection instance. Will reuse an existing mongoose connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
- * Otherwise a new mongoose connection (connection pool) will be created.
- * @param {string} url the uri of the mongodb
- * @param {object} mongooseConnection an existing mongoose connection. If exists, it will be resued for the mongoose connection
- * @param {function} cb the callback function
- */
-function getMongooseConnection(uri, mongooseConnection, cb) {
-  logger.debug("getting mongoose connection");
-  var mongooseConn;
-  if (mongooseConnection && typeof mongooseConnection.useDb === 'function') {
-    process.nextTick(function() {
-      logger.debug("creating the mongoose connection using the existing connection", {uri: uri});
-      var dbName = getDbName(uri);
-      mongooseConn = mongooseConnection.useDb(dbName);
-      return cb(undefined, mongooseConn);
-    });
-  } else {
-    process.nextTick(function() {
-      logger.debug("creating a new mongoose connection", {uri: uri});
-      mongooseConn = mongoose.createConnection(uri);
-      return cb(undefined, mongooseConn);
-    });
-  }
-}
-
-/**
- * Get a new mongodb connection instance. Will reuse an existing mongodb connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
- * Otherwise a new mongodb connection (connection pool) will be created.
- * @param {string} url the uri of the mongodb
- * @param {object} mongodbConnection an existing mongodb connection. If exists, it will be resued for the mongodb connection
- * @param {function} cb the callback function
- */
-function getMongoConnection(uri, mongodbConnection, cb) {
-  logger.debug("getting mongodb connection");
-  var mongoConn;
-  if (mongodbConnection && typeof mongodbConnection.db === 'function') {
-    process.nextTick(function() {
-      logger.debug("creating the mongodb connection using the existing connection", {uri: uri});
-      var dbName = getDbName(uri);
-      mongoConn = mongodbConnection.db(dbName);
-      return cb(undefined, mongoConn);
-    });
-  } else {
-    logger.debug("creating a new mongodb connection", {uri: uri});
-    return MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(cb) : cb);
-  }
-}
+var setupConnections = require('./utils/setup_connections');
 
 var forms = {
   sharedConnections : {},
@@ -88,8 +32,8 @@ var forms = {
 
     logger.info("Initialising mongo connections");
 
-    async.series([
-      function(cb) {
+    async.series({
+      validateParam: function(cb) {
         logger.debug("valid params", options);
         paramValidation.has("uri", function(failed) {
           if (failed) {
@@ -99,19 +43,19 @@ var forms = {
           }
         });
       },
-      async.apply(getMongooseConnection, uri, forms.sharedConnections.mongooseConnection),
-      async.apply(getMongoConnection, uri, forms.sharedConnections.databaseConnection)
-    ], function(err, results) {
+      mongooseConnection: async.apply(setupConnections.getMongooseConnection, uri, forms.sharedConnections.mongooseConnection),
+      mongoConnection: async.apply(setupConnections.getMongoConnection, uri, forms.sharedConnections.databaseConnection)
+    }, function(err, requiredConnections) {
       if (err) {
         logger.error("Error connecting to mongo using client", err);
         return cb(err);
       }
 
-      logger.info("Connected to mongo", {results: results});
+      logger.info("Connected to mongo", {requiredConnections: requiredConnections});
 
       var connections =  {
-        "mongooseConnection": results[1],
-        "databaseConnection": results[2]
+        "mongooseConnection": requiredConnections.mongooseConnection,
+        "databaseConnection": requiredConnections.mongoConnection
       };
 
       self.connections[key] = connections;
@@ -149,6 +93,12 @@ var forms = {
     }
   },
 
+  /**
+   * Set the shared db connections for the module.
+   * @param {object} dbConnections shared database connections
+   * @param {object} dbConnections.mongodbConnection shared mongodb connection
+   * @param {object} dbConnections.mongooseConnection shared mongoose connection
+   */
   setSharedConnections: function(dbConnections) {
     forms.sharedConnections = {
       mongodbConnection: dbConnections.mongodbConnection,

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -1,5 +1,7 @@
 var mongoose = require('mongoose');
 var _ = require('underscore');
+var async = require('async');
+var mongoUriParser = require('mongodb-uri');
 var models = require('../lib/common/models.js')();
 var MongoClient = require('mongodb').MongoClient;
 var validate = require('./common/validate.js');
@@ -13,8 +15,63 @@ var dataTargetImpl = require('./impl/dataTargets');
 var config = require('./config');
 var logger = logfns.getLogger();
 
+function getDbName(uri) {
+  var parsedMongooseUri = mongoUriParser.parse(uri);
+  var dbName = parsedMongooseUri.database;
+  return dbName;
+}
+
+/**
+ * Get a new mongoose connection instance. Will reuse an existing mongoose connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
+ * Otherwise a new mongoose connection (connection pool) will be created.
+ * @param {string} url the uri of the mongodb
+ * @param {object} mongooseConnection an existing mongoose connection. If exists, it will be resued for the mongoose connection
+ * @param {function} cb the callback function
+ */
+function getMongooseConnection(uri, mongooseConnection, cb) {
+  logger.debug("getting mongoose connection");
+  var mongooseConn;
+  if (mongooseConnection && typeof mongooseConnection.useDb === 'function') {
+    process.nextTick(function() {
+      logger.debug("creating the mongoose connection using the existing connection", {uri: uri});
+      var dbName = getDbName(uri);
+      mongooseConn = mongooseConnection.useDb(dbName);
+      return cb(undefined, mongooseConn);
+    });
+  } else {
+    process.nextTick(function() {
+      logger.debug("creating a new mongoose connection", {uri: uri});
+      mongooseConn = mongoose.createConnection(uri);
+      return cb(undefined, mongooseConn);
+    });
+  }
+}
+
+/**
+ * Get a new mongodb connection instance. Will reuse an existing mongodb connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
+ * Otherwise a new mongodb connection (connection pool) will be created.
+ * @param {string} url the uri of the mongodb
+ * @param {object} mongodbConnection an existing mongodb connection. If exists, it will be resued for the mongodb connection
+ * @param {function} cb the callback function
+ */
+function getMongoConnection(uri, mongodbConnection, cb) {
+  logger.debug("getting mongodb connection");
+  var mongoConn;
+  if (mongodbConnection && typeof mongodbConnection.db === 'function') {
+    process.nextTick(function() {
+      logger.debug("creating the mongodb connection using the existing connection", {uri: uri});
+      var dbName = getDbName(uri);
+      mongoConn = mongodbConnection.db(dbName);
+      return cb(undefined, mongoConn);
+    });
+  } else {
+    logger.debug("creating a new mongodb connection", {uri: uri});
+    return MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(cb) : cb);
+  }
+}
 
 var forms = {
+  sharedConnections : {},
   connections: {},
   setConfig: config.set,
 
@@ -26,39 +83,42 @@ var forms = {
     if ( self.connections[key] ) {
       return cb(undefined, self.connections[key]);
     }
+    mongoose.Promise = global.Promise;
     var paramValidation = validate(options);
 
     logger.info("Initialising mongo connections");
 
-    function handleConnectionResponse(err, databaseConn) {
+    async.series([
+      function(cb) {
+        logger.debug("valid params", options);
+        paramValidation.has("uri", function(failed) {
+          if (failed) {
+            return cb(new Error("Invalid Params: " + JSON.stringify(failed)));
+          } else {
+            return cb();
+          }
+        });
+      },
+      async.apply(getMongooseConnection, uri, forms.sharedConnections.mongooseConnection),
+      async.apply(getMongoConnection, uri, forms.sharedConnections.databaseConnection)
+    ], function(err, results) {
       if (err) {
         logger.error("Error connecting to mongo using client", err);
         return cb(err);
       }
 
-      logger.info("Connected to mongo");
+      logger.info("Connected to mongo", {results: results});
 
-      mongoose.Promise = global.Promise;
       var connections =  {
-        "databaseConnection": databaseConn,
-        "mongooseConnection": mongoose.createConnection(uri)
+        "mongooseConnection": results[1],
+        "databaseConnection": results[2]
       };
 
       self.connections[key] = connections;
 
-
       models.init(connections.mongooseConnection, config); //Initialise the models on the created mongoose connection.
 
-      return cb(undefined, connections); //Successful completion of connection, no error returned.
-    }
-
-    paramValidation.has("uri", function(failed) {
-      if (failed) {
-        return cb(new Error("Invalid Params: " + JSON.stringify(failed)));
-      }
-
-      //Ensuring that the mongoClient call is bound to the namespace to ensure the request ID is specified if there is an error.
-      MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(handleConnectionResponse) : handleConnectionResponse);
+      return cb(undefined, connections);
     });
   },
 
@@ -87,6 +147,13 @@ var forms = {
     } else  {
       cb(null);
     }
+  },
+
+  setSharedConnections: function(dbConnections) {
+    forms.sharedConnections = {
+      mongodbConnection: dbConnections.mongodbConnection,
+      mongooseConnection: dbConnections.mongooseConnection
+    };
   },
 
   getForms: function(options, cb) {

--- a/lib/impl/getForm.js
+++ b/lib/impl/getForm.js
@@ -85,8 +85,6 @@ var getForm = function(connections, options, cb) {
         }
       } else if (options.getAllForms && allowedForms) {
         query._id = { $in: allowedForms};
-      } else {
-        query = {};
       }
 
       Form.find(query).populate("pages", "-__v")

--- a/lib/impl/getForm.js
+++ b/lib/impl/getForm.js
@@ -83,12 +83,10 @@ var getForm = function(connections, options, cb) {
             return cb(new Error("Not allowed access to that form: " + formId));
           }
         }
+      } else if (options.getAllForms && allowedForms) {
+        query._id = { $in: allowedForms};
       } else {
-        if (options.getAllForms && allowedForms) {
-          query._id = { $in: allowedForms};
-        } else {
-          query = {};
-        }
+        query = {};
       }
 
       Form.find(query).populate("pages", "-__v")

--- a/lib/impl/submitFormData.js
+++ b/lib/impl/submitFormData.js
@@ -173,15 +173,13 @@ var submitFormData = function(connections, options, cb) {
       Field.findOne({"_id" : f.fieldId}, function(err, fetched) {
         if (err) {
           return callback(err);
-        } else {
-          if (fetched && 'number' === fetched.type) {
-            for (var i=0; i < f.fieldValues.length; i++) {
-              f.fieldValues[i] = parseFloat(f.fieldValues[i]);
-            }
-            callback(undefined,f);
-          } else {
-            callback(undefined,f);
+        } else if (fetched && 'number' === fetched.type) {
+          for (var i=0; i < f.fieldValues.length; i++) {
+            f.fieldValues[i] = parseFloat(f.fieldValues[i]);
           }
+          callback(undefined,f);
+        } else {
+          callback(undefined,f);
         }
       });
     },cb);

--- a/lib/impl/updateTheme.js
+++ b/lib/impl/updateTheme.js
@@ -127,15 +127,12 @@ module.exports = function(connections, options, themeData, cb) {
 
       if (theme !== null) {
         return cb(undefined, theme, themeData);
+      } else if (options.createIfNotFound) {
+        doCreate(themeData, function(err, createdTheme) {
+          return cb(err, createdTheme, themeData);
+        });
       } else {
-        if (options.createIfNotFound) {
-          doCreate(themeData, function(err, createdTheme) {
-            return cb(err, createdTheme, themeData);
-          });
-        } else {
-          return cb(new Error("No theme matches id " + themeId));
-        }
-
+        return cb(new Error("No theme matches id " + themeId));
       }
     });
   }

--- a/lib/shared-mongo-connections.js
+++ b/lib/shared-mongo-connections.js
@@ -32,7 +32,7 @@ function getAdminDbUrl(mongoConnectionString, mongoConf) {
  * @param {function} cb the callback function
  */
 function getMongodbConnection(mongoAdminDbUrl, logger, cb) {
-  logger.debug("creating mongodb connection for data_source_update job", {mongoAdminDbUrl});
+  logger.debug("creating mongodb connection for data_source_update job", {mongoAdminDbUrl: mongoAdminDbUrl});
   MongoClient.connect(mongoAdminDbUrl, cb);
 }
 
@@ -43,7 +43,7 @@ function getMongodbConnection(mongoAdminDbUrl, logger, cb) {
  * @param {function} cb the callback function
  */
 function getMongooseConnection(mongoAdminDbUrl, logger, cb) {
-  logger.debug("creating mongoose connection for data_source_update job", {mongoAdminDbUrl});
+  logger.debug("creating mongoose connection for data_source_update job", {mongoAdminDbUrl: mongoAdminDbUrl});
   var mongooseConnection = mongoose.createConnection(mongoAdminDbUrl);
   return cb(undefined, mongooseConnection);
 }
@@ -56,15 +56,15 @@ function getMongooseConnection(mongoAdminDbUrl, logger, cb) {
  * @param {function} cb the callback function
  */
 module.exports = function(logger, mongoConnectionString, config, cb) {
-  logger.debug("setup mongodb connections", {mongoConnectionString, config});
+  logger.debug("setup mongodb connections", {mongoConnectionString: mongoConnectionString, config: config});
   var mongoAdminDbUrl = getAdminDbUrl(mongoConnectionString, config.mongo);
-  logger.debug("formated mongo connection url", {mongoAdminDbUrl});
+  logger.debug("formated mongo connection url", {mongoAdminDbUrl: mongoAdminDbUrl});
   async.series([
     async.apply(getMongodbConnection, mongoAdminDbUrl, logger),
     async.apply(getMongooseConnection, mongoAdminDbUrl, logger)
-  ], function(err, results){
+  ], function(err, results) {
     if (err) {
-      logger.error("Failed to setup db connection", {err});
+      logger.error("Failed to setup db connection", {error: err});
       return cb(err);
     }
     return cb(undefined, {

--- a/lib/shared-mongo-connections.js
+++ b/lib/shared-mongo-connections.js
@@ -6,70 +6,75 @@ var mongoose = require('mongoose');
 var MONGODB_DEFAULT_POOL_SIZE = 20;
 
 /**
- * Get the url to connect to the admin mongodb specified in the given `config` object.
+ * Get the url of the mongodb database that will the given formUser to connect.
  * @param {string} mongoConnectionString a mongodb url that should at least contain the mongodb hosts
- * @param {object} mongoConf the mongodb configuration
- * @param {string} mongoConf.admin_auth.user the admin username
- * @param {string} mongoConf.admin_auth.pass the amdin user password
- * @param {int} mongoConf.poolSize the poolSize of the mongodb connection. Default to 20.
- * @return {string} the mongodb admin connection url
+ * @param {object} formUser a mongodb user that should have the "readWriteAnyDatabase" role to access any database. This type of user should exist in the mongo `admin` database.
+ * @param {string} formUser.user the username
+ * @param {string} formUser.pass the user password
+ * @param {int} poolSize the poolSize of the mongodb connection. Default to 20.
+ * @return {string} the mongodb connection url
  */
-function getAdminDbUrl(mongoConnectionString, mongoConf) {
+function getAdminDbUrl(mongoConnectionString, formUser, poolSize) {
   var parsedMongoUrl = mongoUrlParser.parse(mongoConnectionString);
-  parsedMongoUrl.username = mongoConf.admin_auth.user;
-  parsedMongoUrl.password = mongoConf.admin_auth.pass;
+  parsedMongoUrl.username = formUser.user;
+  parsedMongoUrl.password = formUser.pass;
+  //according to this: https://docs.mongodb.com/v2.4/reference/user-privileges/#any-database-roles, this type of user should be created in the `admin` database.
   parsedMongoUrl.database = "admin";
   parsedMongoUrl.options = parsedMongoUrl.options || {};
-  parsedMongoUrl.options.poolSize = mongoConf.poolSize || MONGODB_DEFAULT_POOL_SIZE;
+  parsedMongoUrl.options.poolSize = poolSize || MONGODB_DEFAULT_POOL_SIZE;
   var mongourl = mongoUrlParser.format(parsedMongoUrl);
   return mongourl;
 }
 
 /**
- * Create a new mongodb admin connection.
- * @param {string} mongoAdminDbUrl the url to connect to the mongodb admin database
+ * Create a new mongodb connection.
+ * @param {string} mongoDbUrl the url to connect to the mongodb database
  * @param {object} logger
  * @param {function} cb the callback function
  */
-function getMongodbConnection(mongoAdminDbUrl, logger, cb) {
-  logger.debug("creating mongodb connection for data_source_update job", {mongoAdminDbUrl: mongoAdminDbUrl});
-  MongoClient.connect(mongoAdminDbUrl, cb);
+function getMongodbConnection(mongoDbUrl, logger, cb) {
+  logger.debug("creating mongodb connection for data_source_update job", {mongoDbUrl: mongoDbUrl});
+  MongoClient.connect(mongoDbUrl, cb);
 }
 
 /**
- * Create a new mongoose admin connection.
- * @param {string} mongoAdminDbUrl the url to connect to the mongodb admin database
+ * Create a new mongoose connection.
+ * @param {string} mongoDbUrl the url to connect to the mongodb database
  * @param {object} logger
  * @param {function} cb the callback function
  */
-function getMongooseConnection(mongoAdminDbUrl, logger, cb) {
-  logger.debug("creating mongoose connection for data_source_update job", {mongoAdminDbUrl: mongoAdminDbUrl});
-  var mongooseConnection = mongoose.createConnection(mongoAdminDbUrl);
+function getMongooseConnection(mongoDbUrl, logger, cb) {
+  logger.debug("creating mongoose connection for data_source_update job", {mongoDbUrl: mongoDbUrl});
+  var mongooseConnection = mongoose.createConnection(mongoDbUrl);
   return cb(undefined, mongooseConnection);
 }
 
 /**
  * Setup new mongodb and mongoose connections to the given database.
  * @param {object} logger
- * @param {string} mongoAdminDbUrl  the mongodb connection string
+ * @param {string} mongoConnectionString  the mongodb connection string
  * @param {object} config the configuration object
+ * @param {object} config.auth the form user authentication details
+ * @param {string} config.auth.user the form user name
+ * @param {string} config.auth.pass the form user pass
+ * @param {int} config.poolSize the mongodb connection poolSize config
  * @param {function} cb the callback function
  */
 module.exports = function(logger, mongoConnectionString, config, cb) {
   logger.debug("setup mongodb connections", {mongoConnectionString: mongoConnectionString, config: config});
-  var mongoAdminDbUrl = getAdminDbUrl(mongoConnectionString, config.mongo);
-  logger.debug("formated mongo connection url", {mongoAdminDbUrl: mongoAdminDbUrl});
-  async.series([
-    async.apply(getMongodbConnection, mongoAdminDbUrl, logger),
-    async.apply(getMongooseConnection, mongoAdminDbUrl, logger)
-  ], function(err, results) {
+  var mongoDbUrl = getAdminDbUrl(mongoConnectionString, config.auth, config.poolSize);
+  logger.debug("formated mongo connection url", {mongoDbUrl: mongoDbUrl});
+  async.series({
+    mongoConnection: async.apply(getMongodbConnection, mongoDbUrl, logger),
+    mongooseConnection: async.apply(getMongooseConnection, mongoDbUrl, logger)
+  }, function(err, connections) {
     if (err) {
       logger.error("Failed to setup db connection", {error: err});
       return cb(err);
     }
     return cb(undefined, {
-      mongodbConnection: results[0],
-      mongooseConnection: results[1]
+      mongodbConnection: connections.mongoConnection,
+      mongooseConnection: connections.mongooseConnection
     });
   });
 };

--- a/lib/shared-mongo-connections.js
+++ b/lib/shared-mongo-connections.js
@@ -1,0 +1,75 @@
+var mongoUrlParser = require('mongodb-uri');
+var async = require('async');
+var MongoClient = require('mongodb').MongoClient;
+var mongoose = require('mongoose');
+
+var MONGODB_DEFAULT_POOL_SIZE = 20;
+
+/**
+ * Get the url to connect to the admin mongodb specified in the given `config` object.
+ * @param {string} mongoConnectionString a mongodb url that should at least contain the mongodb hosts
+ * @param {object} mongoConf the mongodb configuration
+ * @param {string} mongoConf.admin_auth.user the admin username
+ * @param {string} mongoConf.admin_auth.pass the amdin user password
+ * @param {int} mongoConf.poolSize the poolSize of the mongodb connection. Default to 20.
+ * @return {string} the mongodb admin connection url
+ */
+function getAdminDbUrl(mongoConnectionString, mongoConf) {
+  var parsedMongoUrl = mongoUrlParser.parse(mongoConnectionString);
+  parsedMongoUrl.username = mongoConf.admin_auth.user;
+  parsedMongoUrl.password = mongoConf.admin_auth.pass;
+  parsedMongoUrl.database = "admin";
+  parsedMongoUrl.options = parsedMongoUrl.options || {};
+  parsedMongoUrl.options.poolSize = mongoConf.poolSize || MONGODB_DEFAULT_POOL_SIZE;
+  var mongourl = mongoUrlParser.format(parsedMongoUrl);
+  return mongourl;
+}
+
+/**
+ * Create a new mongodb admin connection.
+ * @param {string} mongoAdminDbUrl the url to connect to the mongodb admin database
+ * @param {object} logger
+ * @param {function} cb the callback function
+ */
+function getMongodbConnection(mongoAdminDbUrl, logger, cb) {
+  logger.debug("creating mongodb connection for data_source_update job", {mongoAdminDbUrl});
+  MongoClient.connect(mongoAdminDbUrl, cb);
+}
+
+/**
+ * Create a new mongoose admin connection.
+ * @param {string} mongoAdminDbUrl the url to connect to the mongodb admin database
+ * @param {object} logger
+ * @param {function} cb the callback function
+ */
+function getMongooseConnection(mongoAdminDbUrl, logger, cb) {
+  logger.debug("creating mongoose connection for data_source_update job", {mongoAdminDbUrl});
+  var mongooseConnection = mongoose.createConnection(mongoAdminDbUrl);
+  return cb(undefined, mongooseConnection);
+}
+
+/**
+ * Setup new mongodb and mongoose connections to the given database.
+ * @param {object} logger
+ * @param {string} mongoAdminDbUrl  the mongodb connection string
+ * @param {object} config the configuration object
+ * @param {function} cb the callback function
+ */
+module.exports = function(logger, mongoConnectionString, config, cb) {
+  logger.debug("setup mongodb connections", {mongoConnectionString, config});
+  var mongoAdminDbUrl = getAdminDbUrl(mongoConnectionString, config.mongo);
+  logger.debug("formated mongo connection url", {mongoAdminDbUrl});
+  async.series([
+    async.apply(getMongodbConnection, mongoAdminDbUrl, logger),
+    async.apply(getMongooseConnection, mongoAdminDbUrl, logger)
+  ], function(err, results){
+    if (err) {
+      logger.error("Failed to setup db connection", {err});
+      return cb(err);
+    }
+    return cb(undefined, {
+      mongodbConnection: results[0],
+      mongooseConnection: results[1]
+    });
+  });
+};

--- a/lib/templates/helpers.js
+++ b/lib/templates/helpers.js
@@ -209,10 +209,8 @@ Handlebars.registerHelper('is', function() {
   var fieldType = args.pop();
   if (args.indexOf(fieldType) > -1) {
     return options.fn(this);
-  } else {
-    if ('function' === typeof options.inverse) {
-      return options.inverse(this);
-    }
+  } else if ('function' === typeof options.inverse) {
+    return options.inverse(this);
   }
 });
 

--- a/lib/utils/setup_connections.js
+++ b/lib/utils/setup_connections.js
@@ -34,7 +34,7 @@ function getMongooseConnection(uri, mongooseConnection, cb) {
     });
   } else {
     process.nextTick(function() {
-      logger.debug("creating a new mongoose connection", {uri: uri});
+      logger.warn("creating a new mongoose connection", {uri: uri});
       mongooseConn = mongoose.createConnection(uri);
       return cb(undefined, mongooseConn);
     });
@@ -59,7 +59,7 @@ function getMongoConnection(uri, mongodbConnection, cb) {
       return cb(undefined, mongoConn);
     });
   } else {
-    logger.debug("creating a new mongodb connection", {uri: uri});
+    logger.warn("creating a new mongodb connection", {uri: uri});
     return MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(cb) : cb);
   }
 }

--- a/lib/utils/setup_connections.js
+++ b/lib/utils/setup_connections.js
@@ -1,0 +1,70 @@
+var logfns = require('../common/logger.js');
+var logger = logfns.getLogger();
+var mongoUriParser = require('mongodb-uri');
+var mongoose = require('mongoose');
+var MongoClient = require('mongodb').MongoClient;
+
+/**
+ * Get the database name from the given mongodb uri.
+ * @param {string} uri the mongodb uri
+ * @returns {string} the name of the mongodb database
+ */
+function getDbName(uri) {
+  var parsedMongooseUri = mongoUriParser.parse(uri);
+  var dbName = parsedMongooseUri.database;
+  return dbName;
+}
+
+/**
+ * Get a new mongoose connection instance. Will reuse an existing mongoose connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
+ * Otherwise a new mongoose connection (connection pool) will be created.
+ * @param {string} url the uri of the mongodb
+ * @param {object} mongooseConnection an existing mongoose connection. If exists, it will be resued for the mongoose connection
+ * @param {function} cb the callback function
+ */
+function getMongooseConnection(uri, mongooseConnection, cb) {
+  logger.debug("getting mongoose connection");
+  var mongooseConn;
+  if (mongooseConnection && typeof mongooseConnection.useDb === 'function') {
+    process.nextTick(function() {
+      logger.debug("creating the mongoose connection using the existing connection", {uri: uri});
+      var dbName = getDbName(uri);
+      mongooseConn = mongooseConnection.useDb(dbName);
+      return cb(undefined, mongooseConn);
+    });
+  } else {
+    process.nextTick(function() {
+      logger.debug("creating a new mongoose connection", {uri: uri});
+      mongooseConn = mongoose.createConnection(uri);
+      return cb(undefined, mongooseConn);
+    });
+  }
+}
+
+/**
+ * Get a new mongodb connection instance. Will reuse an existing mongodb connection if it's passed in (this connection should be authenticated already and have access to the target db. E.g. admin user).
+ * Otherwise a new mongodb connection (connection pool) will be created.
+ * @param {string} url the uri of the mongodb
+ * @param {object} mongodbConnection an existing mongodb connection. If exists, it will be resued for the mongodb connection
+ * @param {function} cb the callback function
+ */
+function getMongoConnection(uri, mongodbConnection, cb) {
+  logger.debug("getting mongodb connection");
+  var mongoConn;
+  if (mongodbConnection && typeof mongodbConnection.db === 'function') {
+    process.nextTick(function() {
+      logger.debug("creating the mongodb connection using the existing connection", {uri: uri});
+      var dbName = getDbName(uri);
+      mongoConn = mongodbConnection.db(dbName);
+      return cb(undefined, mongoConn);
+    });
+  } else {
+    logger.debug("creating a new mongodb connection", {uri: uri});
+    return MongoClient.connect(uri, logger.ensureRequestId ? logger.ensureRequestId(cb) : cb);
+  }
+}
+
+module.exports = {
+  getMongoConnection: getMongoConnection,
+  getMongooseConnection: getMongooseConnection
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "mmmagic": "^0.4.1",
     "moment": "2.14.1",
     "mongodb": "2.1.18",
+    "mongodb-uri": "0.9.7",
     "mongoose": "4.5.0",
     "mongoose-paginate": "5.0.3",
     "phantom": "2.1.21",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-forms
 sonar.projectName=fh-forms-nightly-master
-sonar.projectVersion=1.11.1
+sonar.projectVersion=1.12.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/test_shared_mongo_connections.js
+++ b/test/unit/test_shared_mongo_connections.js
@@ -21,12 +21,11 @@ var underTest = proxyquire('../../lib/shared-mongo-connections', {
 exports.testGetSharedMongodb = function(done) {
   var mongoString = "mongo://test.example.me/test";
   var config = {
-    mongo: {
-      admin_auth: {
-        user: 'test',
-        pass: 'test'
-      }
-    }
+    auth : {
+      user: 'test',
+      pass: 'test'
+    },
+    poolSize: 10
   };
   var mongoConnection = "mongoConnection";
   var mongooseConnection = "mongooseConnection";

--- a/test/unit/test_shared_mongo_connections.js
+++ b/test/unit/test_shared_mongo_connections.js
@@ -1,0 +1,42 @@
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var logger = require('../../lib/common/logger');
+var log = logger.getLogger();
+
+var mongoClient = sinon.stub();
+var mongooseConnect = sinon.stub();
+
+var underTest = proxyquire('../../lib/shared-mongo-connections', {
+  'mongodb': {
+    MongoClient: {
+      connect: mongoClient
+    }
+  },
+  'mongoose': {
+    createConnection: mongooseConnect
+  }
+});
+
+exports.testGetSharedMongodb = function(done) {
+  var mongoString = "mongo://test.example.me/test";
+  var config = {
+    mongo: {
+      admin_auth: {
+        user: 'test',
+        pass: 'test'
+      }
+    }
+  };
+  var mongoConnection = "mongoConnection";
+  var mongooseConnection = "mongooseConnection";
+  mongoClient.yields(null, mongoConnection);
+  mongooseConnect.returns(mongooseConnection);
+
+  underTest(log, mongoString, config, function(err, connections) {
+    assert.ok(!err);
+    assert.equal(connections.mongodbConnection,  mongoConnection);
+    assert.equal(connections.mongooseConnection, mongooseConnection);
+    done();
+  });
+};

--- a/test/unit/utils/test_setup_connections.js
+++ b/test/unit/utils/test_setup_connections.js
@@ -1,0 +1,66 @@
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+
+var mongooseConnectStub = sinon.stub();
+var mongoClientConnectStub = sinon.stub();
+var mongourl = "mongo://test.example.com";
+
+var underTest = proxyquire('../../../lib/utils/setup_connections', {
+  mongoose: {
+    createConnection: mongooseConnectStub
+  },
+  mongodb: {
+    MongoClient: {
+      connect: mongoClientConnectStub
+    }
+  }
+});
+
+exports.testNewMongooseConnection = function(done) {
+  mongooseConnectStub.reset();
+  mongooseConnectStub.returns("newConnection");
+  underTest.getMongooseConnection(mongourl, null, function(err, mongooseConnection){
+    assert.ok(!err);
+    assert.ok(mongooseConnection);
+    assert.ok(mongooseConnectStub.calledOnce);
+    done();
+  });
+};
+
+exports.testReuseExistingMongooseConnection = function(done) {
+  mongooseConnectStub.reset();
+  var existingConnection = {useDb: sinon.stub()};
+  existingConnection.useDb.returns("existingConnection");
+  underTest.getMongooseConnection(mongourl, existingConnection, function(err, mongooseConnection) {
+    assert.ok(!err);
+    assert.ok(mongooseConnection);
+    assert.equal(0, mongooseConnectStub.callCount);
+    assert.ok(existingConnection.useDb.calledOnce);
+    done();
+  });
+};
+
+exports.testNewMongoConnection = function(done) {
+  mongoClientConnectStub.reset();
+  mongoClientConnectStub.yields(null, "newConnection");
+  underTest.getMongoConnection(mongourl, null, function(err, mongoConnection){
+    assert.ok(!err);
+    assert.ok(mongoConnection);
+    assert.ok(mongoClientConnectStub.calledOnce);
+    done();
+  });
+};
+
+exports.testExistingMongoConnnection = function(done) {
+  mongoClientConnectStub.reset();
+  var existingConnection = {db: sinon.stub()};
+  existingConnection.db.returns("existingConnection");
+  underTest.getMongoConnection(mongourl, existingConnection, function(err, mongoConnection) {
+    assert.ok(!err);
+    assert.ok(mongoConnection);
+    assert.equal(0, mongoClientConnectStub.callCount);
+    assert.ok(existingConnection.db.calledOnce);
+    done();
+  });
+}


### PR DESCRIPTION
## Motive

At the moment, fh-forms will create new mongodb connections for every environment database. Because of how mongodb connection works (it is in fact a connection pool), we are seeing excessive amount of mongodb connections created in production.

## Changes

Allow set shared mongodb  connection for fh-forms to use. It the shared mongodb connections are set, they will be used (so that no new connections will be created). Otherwise it will continue to work as before.

## JIRA

https://issues.jboss.org/browse/RHMAP-11889

ping @nialldonnellyfh @pb82 @sedroche 
