### PR TITLE
Added repeating sections validation to the rules engine

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
     fhignore: ['client/**'],
 
     _unit_runner: '_mocha',
-    _unit_args: '-A -u exports --recursive -t 10000 ./test/unit/',
+    _unit_args: '-A -u exports --recursive -t 10000 ./test/unit',
     unit: '<%= _unit_runner %> <%= _unit_args %>',
     unit_cover: 'istanbul cover --dir cov-unit <%= _unit_runner %> -- <%= _unit_args %>',
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
     fhignore: ['client/**'],
 
     _unit_runner: '_mocha',
-    _unit_args: '-A -u exports --recursive -t 10000 ./test/unit',
+    _unit_args: '-A -u exports --recursive -t 10000 ./test/unit/',
     unit: '<%= _unit_runner %> <%= _unit_args %>',
     unit_cover: 'istanbul cover --dir cov-unit <%= _unit_runner %> -- <%= _unit_args %>',
 

--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -81,6 +81,8 @@
     var pageRulePredicateMap = {};
     var pageRuleSubjectMap = {};
     var submissionFieldsMap = {};
+
+    //Mapping fieldId to their section Ids if a field is contained in a section
     var fieldSectionMapping = {};
 
     var validatorsMap = {
@@ -351,6 +353,7 @@
           if (field.required) {
             requiredFieldMap[field._id] = {
               field: field,
+              //Validation details for each section index
               sections: {},
               validated: false,
               valueRequired: field.required
@@ -444,6 +447,8 @@
           return;
         }
 
+        //The section index should be part of the field input, however for backwards compatibility, it should
+        //default to 0
         formField.sectionIndex = formField.sectionIndex || 0;
 
         /**
@@ -454,12 +459,23 @@
           return;
         }
 
+        //Including the section index the the submission field map. Otherwise submissions with the same field ID but different
+        //section Indexes would overwrite eachother.
+        //This also has an impact when considering the rules. If a rule sources its value from a field in a repeating section and targets a
+        //value in the same section, then the value has to come from the same section index.
         submissionFieldsMap[formField.fieldId] = submissionFieldsMap[formField.fieldId] || {};
         submissionFieldsMap[formField.fieldId][formField.sectionIndex] = formField;
       });
       return error;
     }
 
+    /**
+     *
+     * Initialising the rules engine for a single form.
+     *
+     * This builds up the metadata required to process all rules.
+     *
+     */
     function init() {
       if (initialised) {
         return;
@@ -472,15 +488,27 @@
       initialised = true;
     }
 
+    /**
+     *
+     * Processing a single
+     *
+     * @param {Object} formSubmission - The full JSON definition of the form.
+     * @returns {*}
+     */
     function initSubmission(formSubmission) {
+
+      //Ensuring that the form metadata has been initialised first.
       init();
+
       submission = formSubmission;
       return buildSubmissionFieldsMap();
     }
 
     /**
+     *
      * Getting all of the fields that are in a section
-     * @param sectionId
+     *
+     * @param {string} sectionId
      */
     function getSectionFields(sectionId) {
       var allSectionFields = _.map(fieldSectionMapping, function(_sectionId, fieldId) {
@@ -494,14 +522,13 @@
      *
      * Checking for too many repeating sections passed.
      *
-     * @param validationResponse
-     * @param callback
+     * @param {object} validationResponse - The full validation response to update
+     * @param {function} callback - Used because it is part of an async.waterfall in the validateForm function
      */
     function checkForTooManyRepeatingSections(validationResponse, callback) {
       var repeatingSections = getAllRepeatingSections();
 
       //For each of the repeating sections, check that no values have been submitted with an index too large.
-
       _.each(repeatingSections, function(repeatingSection) {
         var maxRepeat = getSectionMaxRepeat(repeatingSection._id);
 
@@ -532,6 +559,15 @@
       callback(undefined, validationResponse);
     }
 
+    /**
+     *
+     * Getting previous values for a single field from a previous submission
+     *
+     * @param {object} submittedField - The field submitted
+     * @param {object|null} previousSubmission - Full JSON definition of the previous submission to get the values from
+     * @param {function} cb
+     * @returns {*}
+     */
     function getPreviousFieldValues(submittedField, previousSubmission, cb) {
       if (previousSubmission && previousSubmission.formFields) {
         async.filter(previousSubmission.formFields, function(formField, cb) {
@@ -548,16 +584,31 @@
       }
     }
 
+    /**
+     *
+     * Validating a full submission against a form definition
+     *
+     * @param {object} submission - The full JSON definition of the submission.
+     * @param {object} [previousSubmission] - Optional previous submission if values need to be compared.
+     * @param {function} cb
+     * @returns {*}
+     */
     function validateForm(submission, previousSubmission, cb) {
       if ("function" === typeof previousSubmission) {
         cb = previousSubmission;
         previousSubmission = null;
       }
+
+      //Ensuring the form metadata is initialised
       init();
+
+      //Initialising the submission metatadata for validation
       var err = initSubmission(submission);
       if (err) {
         return cb(err);
       }
+
+      //All of the steps required to validate the submission against the form definition
       async.waterfall([
         function(cb) {
           var response = {
@@ -566,9 +617,12 @@
             }
           };
 
+          //First, validate each of the fields in the passed submission
           validateSubmittedFields(response, previousSubmission, cb);
         },
+        //Now check if any required fields were not submitted
         checkIfRequiredFieldsNotSubmitted,
+        //Now check if too many repeating section field values were passed for any repeating section
         checkForTooManyRepeatingSections
       ], function(err, results) {
         if (err) {
@@ -579,36 +633,47 @@
       });
     }
 
-    function validateSubmittedFields(res, previousSubmission, cb) {
-      // for each field, call validateField
+    /**
+     *
+     * Validating the submitted fields for a single submission
+     *
+     * @param {object} validationResponse - The full validation response
+     * @param {object|null} previousSubmission - A previous submission to compare against
+     * @param {function} cb
+     */
+    function validateSubmittedFields(validationResponse, previousSubmission, cb) {
+
+      // for each field, validate that the submitted values are valid
       async.each(submission.formFields, function(submittedField, callback) {
         var fieldID = submittedField.fieldId;
         var fieldDef = fieldMap[fieldID];
+
+        //The section index is used to ensure that comparisons are made against the correct section index.
+        //This is used when comparing rule source field values targeting fields in the same section
+        //It is also used when assigning error messages to the validationResponse
         var sectionIndex = submittedField.sectionIndex || 0;
 
         getPreviousFieldValues(submittedField, previousSubmission, function(err, previousFieldValues) {
           if (err) {
             return callback(err);
           }
+
+          //Validing the submitted field against the field definition
           getFieldValidationStatus(submittedField, fieldDef, previousFieldValues, function(err, fieldRes) {
             if (err) {
               return callback(err);
             }
 
             if (!fieldRes.valid) {
-              res.validation.valid = false; // indicate invalid form if any fields invalid
-              assignValidationResponse(fieldID, sectionIndex, res.validation, fieldRes);
+              validationResponse.validation.valid = false; // indicate invalid form if any fields invalid
+              assignValidationResponse(fieldID, sectionIndex, validationResponse.validation, fieldRes);
             }
 
             return callback();
           });
-
         });
       }, function(err) {
-        if (err) {
-          return cb(err);
-        }
-        return cb(undefined, res);
+        return cb(err, validationResponse);
       });
     }
 
@@ -638,14 +703,23 @@
       });
     }
 
-    function assignValidationResponse(fieldId, sectionIndex, validationFieldOutput, validationResponse) {
-      validationFieldOutput[fieldId] = validationFieldOutput[fieldId] || {sections: {}};
-      validationFieldOutput[fieldId].sections[sectionIndex] = validationResponse;
+    /**
+     *
+     * Assiging a field validation response to the correct section index
+     *
+     * @param {string} fieldId
+     * @param {number} sectionIndex
+     * @param {object} globalValidationResponse
+     * @param {object} fieldValidationResponse
+     */
+    function assignValidationResponse(fieldId, sectionIndex, globalValidationResponse, fieldValidationResponse) {
+      globalValidationResponse[fieldId] = globalValidationResponse[fieldId] || {sections: {}};
+      globalValidationResponse[fieldId].sections[sectionIndex] = fieldValidationResponse;
 
+      //For backwards compatiblility, the section 0 validation response is assigned field validation response
       if (sectionIndex === 0) {
-        _.defaults(validationFieldOutput[fieldId], validationFieldOutput[fieldId].sections[0]);
+        _.defaults(globalValidationResponse[fieldId], globalValidationResponse[fieldId].sections[0]);
       }
-
     }
 
     /**
@@ -676,37 +750,58 @@
       });
     }
 
+    /**
+     *
+     * Getting the maximum number of times that a section can repeat.
+     *
+     * @param {string} sectionId
+     * @returns {number} - the number of times a section repeats.
+     */
     function getSectionMaxRepeat(sectionId) {
       var section = fieldMap[sectionId];
 
       return section && section.repeating && section.fieldOptions.definition.maxRepeat ? section.fieldOptions.definition.maxRepeat : 1;
     }
 
+
+    /**
+     *
+     * Checking for any required fields that were not submitted.
+     *
+     * @param {object} validationResponse - The validation response to update with any errors.
+     * @param {function} cb
+     */
     function checkIfRequiredFieldsNotSubmitted(validationResponse, cb) {
 
+      //For each of the required fields, check that the fields have submission values
       async.each(Object.keys(submissionRequiredFieldsMap), function(requiredFieldId, cb) {
         var requiredField = submissionRequiredFieldsMap[requiredFieldId];
 
+        //The minimum number of times a section must repeat, means that the required fields in the section must have valid entries for each
+        //repetition of the field.
         var minRepeat = getSectionMinRepeat(requiredFieldId);
 
         async.each(_.range(minRepeat), function(sectionIndex, sectionCb) {
           var isSubmitted = requiredField && requiredField.sections && requiredField.sections[sectionIndex] && requiredField.sections[sectionIndex].submitted;
 
           if (!isSubmitted) {
+            //Checking if the field for this section index is visible.
+            //This can change based on the section index as rules within the section may source
+            //their values from within the repeating section.
             isFieldVisible(requiredFieldId, true, sectionIndex, function(err, visible) {
-              var resField = {};
+              var fieldValidationDetails = {};
               if (err) {
                 return sectionCb(err);
               }
 
               if (visible && requiredField.valueRequired) { // we only care about required fields if they are visible
-                resField.fieldId = requiredFieldId;
-                resField.valid = false;
-                resField.fieldErrorMessage = ["Required Field Not Submitted"];
-                resField.sectionId = fieldSectionMapping[requiredFieldId];
-                resField.sectionIndex = sectionIndex;
+                fieldValidationDetails.fieldId = requiredFieldId;
+                fieldValidationDetails.valid = false;
+                fieldValidationDetails.fieldErrorMessage = ["Required Field Not Submitted"];
+                fieldValidationDetails.sectionId = fieldSectionMapping[requiredFieldId];
+                fieldValidationDetails.sectionIndex = sectionIndex;
 
-                assignValidationResponse(requiredFieldId, sectionIndex, validationResponse.validation, resField);
+                assignValidationResponse(requiredFieldId, sectionIndex, validationResponse.validation, fieldValidationDetails);
                 validationResponse.validation.valid = false;
               }
               return sectionCb();
@@ -720,7 +815,7 @@
       });
     }
 
-    /*
+    /**
      * validate only field values on validation (no rules, no repeat checking)
      *     res:
      *     "validation":{
@@ -1828,6 +1923,16 @@
       });
     }
 
+    /**
+     *
+     * Checking to see if a rule condition is active.
+     *
+     * @param {object} field - JSON definition of the field
+     * @param {*} fieldValue - The value obtained for the field from the submission
+     * @param {*} testValue - The value to compare against to see if the condition is active.
+     * @param {string} condition - The condition to compare the values (E.g. "is equal to")
+     * @returns {*}
+     */
     function isConditionActive(field, fieldValue, testValue, condition) {
 
       var fieldType = field.type;

--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -350,7 +350,9 @@
 
           fieldMap[field._id] = field;
 
-          if (field.required) {
+          //Section/Page Breaks are not considered to be required as they are
+          //structural fields only
+          if (field.required && field.type !== "sectionBreak" && field.type !== "pageBreak") {
             requiredFieldMap[field._id] = {
               field: field,
               //Validation details for each section index

--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -81,6 +81,8 @@
     var pageRulePredicateMap = {};
     var pageRuleSubjectMap = {};
     var submissionFieldsMap = {};
+    var fieldSectionMapping = {};
+
     var validatorsMap = {
       "text": validatorString,
       "textarea": validatorString,
@@ -318,6 +320,14 @@
       return !!pageRuleSubjectMap[pageId];
     };
 
+    /**
+     *
+     * Builds two field maps, both indexed by the field ID.
+     *
+     * - One for all of the fields (fieldMap)
+     * - One for just the required fields (requiredFieldMap)
+     *
+     */
     function buildFieldMap() {
       // Iterate over all fields in form definition & build fieldMap
       _.each(definition.pages, function(page) {
@@ -341,7 +351,7 @@
           if (field.required) {
             requiredFieldMap[field._id] = {
               field: field,
-              submitted: false,
+              sections: {},
               validated: false,
               valueRequired: field.required
             };
@@ -351,6 +361,13 @@
       });
     }
 
+    /**
+     *
+     * Building a map of all of the field targets of different field rules.
+     *
+     * This makes it easier to check if any field is the target of a field rule.
+     *
+     */
     function buildFieldRuleMaps() {
       // Iterate over all rules in form definition & build ruleSubjectMap
       _.each(definition.fieldRules, function(rule) {
@@ -376,6 +393,13 @@
       });
     }
 
+    /**
+     *
+     * Building a map of all of the page targets of different page rules.
+     *
+     * This makes it easier to check if any page is the target of a page rule.
+     *
+     */
     function buildPageRuleMap() {
       // Iterate over all rules in form definition & build ruleSubjectMap
       _.each(definition.pageRules, function(rule) {
@@ -402,6 +426,12 @@
       });
     }
 
+    /**
+     *
+     * Building an index of all of the values made for the submission
+     *
+     * @returns {*}
+     */
     function buildSubmissionFieldsMap() {
       submissionRequiredFieldsMap = JSON.parse(JSON.stringify(requiredFieldMap)); // clone the map for use with this submission
       submissionFieldsMap = {}; // start with empty map, rulesEngine can be called with multiple submissions
@@ -414,6 +444,8 @@
           return;
         }
 
+        formField.sectionIndex = formField.sectionIndex || 0;
+
         /**
          * If the field passed in a submission is an admin field, then return an error.
          */
@@ -422,7 +454,8 @@
           return;
         }
 
-        submissionFieldsMap[formField.fieldId] = formField;
+        submissionFieldsMap[formField.fieldId] = submissionFieldsMap[formField.fieldId] || {};
+        submissionFieldsMap[formField.fieldId][formField.sectionIndex] = formField;
       });
       return error;
     }
@@ -431,6 +464,7 @@
       if (initialised) {
         return;
       }
+      buildSectionMap();
       buildFieldMap();
       buildFieldRuleMaps();
       buildPageRuleMap();
@@ -442,6 +476,60 @@
       init();
       submission = formSubmission;
       return buildSubmissionFieldsMap();
+    }
+
+    /**
+     * Getting all of the fields that are in a section
+     * @param sectionId
+     */
+    function getSectionFields(sectionId) {
+      var allSectionFields = _.map(fieldSectionMapping, function(_sectionId, fieldId) {
+        return sectionId === _sectionId ? fieldMap[fieldId] : null;
+      });
+
+      return _.compact(allSectionFields);
+    }
+
+    /**
+     *
+     * Checking for too many repeating sections passed.
+     *
+     * @param validationResponse
+     * @param callback
+     */
+    function checkForTooManyRepeatingSections(validationResponse, callback) {
+      var repeatingSections = getAllRepeatingSections();
+
+      //For each of the repeating sections, check that no values have been submitted with an index too large.
+
+      _.each(repeatingSections, function(repeatingSection) {
+        var maxRepeat = getSectionMaxRepeat(repeatingSection._id);
+
+        //All of the fields assigned to the repeating section
+        var allSectionFields = getSectionFields(repeatingSection._id);
+
+        //For each of these fields, check that there isn't a section index larger than the max number of section repetitions
+        _.each(allSectionFields, function(sectionField) {
+          var invalidFieldValues = _.filter(submissionFieldsMap[sectionField._id], function(sectionValues, sectionIndex) {
+            return parseInt(sectionIndex) >= maxRepeat;
+          });
+
+          //For each of the invalid field entries, assign the correct messages
+          return _.each(invalidFieldValues, function(invalidFieldValue) {
+            var resField = {};
+            resField.fieldId = invalidFieldValue.fieldId;
+            resField.valid = false;
+            resField.fieldErrorMessage = ["Expected a maximum of " + maxRepeat + " sections but got " + (invalidFieldValue.sectionIndex + 1) + "."];
+            resField.sectionId = fieldSectionMapping[invalidFieldValue.fieldId];
+            resField.sectionIndex = invalidFieldValue.sectionIndex;
+
+            assignValidationResponse(repeatingSection._id, invalidFieldValue.sectionIndex, validationResponse.validation, resField);
+            validationResponse.validation.valid = false;
+          });
+        });
+      });
+
+      callback(undefined, validationResponse);
     }
 
     function getPreviousFieldValues(submittedField, previousSubmission, cb) {
@@ -480,7 +568,8 @@
 
           validateSubmittedFields(response, previousSubmission, cb);
         },
-        checkIfRequiredFieldsNotSubmitted
+        checkIfRequiredFieldsNotSubmitted,
+        checkForTooManyRepeatingSections
       ], function(err, results) {
         if (err) {
           return cb(err);
@@ -495,6 +584,7 @@
       async.each(submission.formFields, function(submittedField, callback) {
         var fieldID = submittedField.fieldId;
         var fieldDef = fieldMap[fieldID];
+        var sectionIndex = submittedField.sectionIndex || 0;
 
         getPreviousFieldValues(submittedField, previousSubmission, function(err, previousFieldValues) {
           if (err) {
@@ -507,7 +597,7 @@
 
             if (!fieldRes.valid) {
               res.validation.valid = false; // indicate invalid form if any fields invalid
-              res.validation[fieldID] = fieldRes; // add invalid field info to validate form result
+              assignValidationResponse(fieldID, sectionIndex, res.validation, fieldRes);
             }
 
             return callback();
@@ -522,35 +612,111 @@
       });
     }
 
-    function checkIfRequiredFieldsNotSubmitted(res, cb) {
+    /**
+     *
+     * Building a map of all of the sections along with the fields contained in them
+     *
+     */
+    function buildSectionMap() {
+      var sectionId = null;
+
+      _.each(definition.pages, function(page) {
+
+        //Resetting the section ID. Sections never cross pages.
+        sectionId = null;
+
+        _.each(page.fields, function(field) {
+          if (field.type === "sectionBreak") {
+            //If the field is a section break, then we are starting a new section
+            sectionId = field._id;
+          } else if (field.type !== "pageBreak") {
+            //It's not a page or section break field.
+            //Assign the section id to the section map
+            fieldSectionMapping[field._id] = sectionId;
+          }
+        });
+      });
+    }
+
+    function assignValidationResponse(fieldId, sectionIndex, validationFieldOutput, validationResponse) {
+      validationFieldOutput[fieldId] = validationFieldOutput[fieldId] || {sections: {}};
+      validationFieldOutput[fieldId].sections[sectionIndex] = validationResponse;
+
+      if (sectionIndex === 0) {
+        _.defaults(validationFieldOutput[fieldId], validationFieldOutput[fieldId].sections[0]);
+      }
+
+    }
+
+    /**
+     *
+     * Getting the minimum number of repetitions for a field in a repeating section
+     *
+     * @param fieldId
+     * @returns {number}
+     */
+    function getSectionMinRepeat(fieldId) {
+      //If the field is in a repeating section, need to check each repeating section
+      var sectionId = fieldSectionMapping[fieldId];
+      var section = sectionId ? fieldMap[sectionId] : null;
+
+      //The field is in a repeating section.
+      return section && section.repeating && section.fieldOptions.definition.minRepeat ? section.fieldOptions.definition.minRepeat : 1;
+    }
+
+    /**
+     *
+     * Getting all repeating sections belonging to this form.
+     *
+     * @returns {Array}
+     */
+    function getAllRepeatingSections() {
+      return _.filter(fieldMap, function(field) {
+        return field.type === "sectionBreak" && field.fieldOptions && field.fieldOptions.definition && field.fieldOptions.definition.maxRepeat;
+      });
+    }
+
+    function getSectionMaxRepeat(sectionId) {
+      var section = fieldMap[sectionId];
+
+      return section && section.repeating && section.fieldOptions.definition.maxRepeat ? section.fieldOptions.definition.maxRepeat : 1;
+    }
+
+    function checkIfRequiredFieldsNotSubmitted(validationResponse, cb) {
+
       async.each(Object.keys(submissionRequiredFieldsMap), function(requiredFieldId, cb) {
-        var resField = {};
         var requiredField = submissionRequiredFieldsMap[requiredFieldId];
 
-        if (!requiredField.submitted) {
-          isFieldVisible(requiredFieldId, true, function(err, visible) {
-            if (err) {
-              return cb(err);
-            }
+        var minRepeat = getSectionMinRepeat(requiredFieldId);
 
-            if (visible && requiredField.valueRequired) { // we only care about required fields if they are visible
-              resField.fieldId = requiredFieldId;
-              resField.valid = false;
-              resField.fieldErrorMessage = ["Required Field Not Submitted"];
-              res.validation[requiredFieldId] = resField;
-              res.validation.valid = false;
-            }
-            return cb();
-          });
-        } else { // was included in submission
-          return cb();
-        }
+        async.each(_.range(minRepeat), function(sectionIndex, sectionCb) {
+          var isSubmitted = requiredField && requiredField.sections && requiredField.sections[sectionIndex] && requiredField.sections[sectionIndex].submitted;
+
+          if (!isSubmitted) {
+            isFieldVisible(requiredFieldId, true, sectionIndex, function(err, visible) {
+              var resField = {};
+              if (err) {
+                return sectionCb(err);
+              }
+
+              if (visible && requiredField.valueRequired) { // we only care about required fields if they are visible
+                resField.fieldId = requiredFieldId;
+                resField.valid = false;
+                resField.fieldErrorMessage = ["Required Field Not Submitted"];
+                resField.sectionId = fieldSectionMapping[requiredFieldId];
+                resField.sectionIndex = sectionIndex;
+
+                assignValidationResponse(requiredFieldId, sectionIndex, validationResponse.validation, resField);
+                validationResponse.validation.valid = false;
+              }
+              return sectionCb();
+            });
+          } else { // was included in submission
+            return sectionCb();
+          }
+        }, cb);
       }, function(err) {
-        if (err) {
-          return cb(err);
-        }
-
-        return cb(undefined, res);
+        return cb(err, validationResponse);
       });
     }
 
@@ -568,15 +734,22 @@
      *             }
      *         }
      */
-    function validateField(fieldId, submission, cb) {
+    function validateField(fieldId, submission, sectionIndex, cb) {
       init();
+
+      if (_.isFunction(sectionIndex)) {
+        cb = sectionIndex;
+        sectionIndex = 0;
+      }
+
       var err = initSubmission(submission);
       if (err) {
         return cb(err);
       }
 
-      var submissionField = submissionFieldsMap[fieldId];
+      var submissionField = submissionFieldsMap[fieldId][sectionIndex];
       var fieldDef = fieldMap[fieldId];
+
       getFieldValidationStatus(submissionField, fieldDef, null, function(err, res) {
         if (err) {
           return cb(err);
@@ -584,7 +757,8 @@
         var ret = {
           validation: {}
         };
-        ret.validation[fieldId] = res;
+
+        assignValidationResponse(fieldId, sectionIndex, ret.validation, res);
         return cb(undefined, ret);
       });
     }
@@ -604,10 +778,16 @@
      *         }
      *     }
      */
-    function validateFieldValue(fieldId, inputValue, valueIndex, cb) {
+    function validateFieldValue(fieldId, inputValue, valueIndex, sectionIndex, cb) {
       if ("function" === typeof valueIndex) {
         cb = valueIndex;
         valueIndex = 0;
+        sectionIndex = 0;
+      }
+
+      if (_.isFunction(sectionIndex)) {
+        cb = sectionIndex;
+        sectionIndex = 0;
       }
 
       init();
@@ -628,11 +808,13 @@
 
       if (validation && false === validation.validateImmediately) {
         var ret = {
-          validation: {}
+          validation: {valid: true}
         };
-        ret.validation[fieldId] = {
+
+        assignValidationResponse(fieldId, sectionIndex, ret.validation, {
           "valid": true
-        };
+        });
+
         return cb(undefined, ret);
       }
 
@@ -672,23 +854,26 @@
         if (msg) {
           messages.errorMessages.push(msg);
         }
-        return createValidatorResponse(fieldId, messages, function(err, res) {
+        return createValidatorResponse(fieldId, messages, sectionIndex, function(err, res) {
           if (err) {
             return cb(err);
           }
           var ret = {
             validation: {}
           };
-          ret.validation[fieldId] = res;
+
+          assignValidationResponse(fieldId, sectionIndex, ret.validation, res);
+
           return cb(undefined, ret);
         });
       }
     }
 
-    function createValidatorResponse(fieldId, messages, cb) {
+    function createValidatorResponse(fieldId, messages, sectionIndex, cb) {
       // intentionally not checking err here, used further down to get validation errors
       var res = {};
       res.fieldId = fieldId;
+      res.sectionIndex = sectionIndex;
       res.errorMessages = messages.errorMessages || [];
       res.fieldErrorMessage = messages.fieldErrorMessage || [];
       async.some(res.errorMessages, function(item, cb) {
@@ -701,15 +886,19 @@
     }
 
     function getFieldValidationStatus(submittedField, fieldDef, previousFieldValues, cb) {
-      isFieldVisible(fieldDef._id, true, function(err, visible) {
+      var sectionIndex = submittedField.sectionIndex || 0;
+
+      isFieldVisible(fieldDef._id, true, sectionIndex, function(err, visible) {
         if (err) {
           return cb(err);
         }
+
         validateFieldInternal(submittedField, fieldDef, previousFieldValues, visible, function(err, messages) {
           if (err) {
             return cb(err);
           }
-          createValidatorResponse(submittedField.fieldId, messages, cb);
+
+          createValidatorResponse(submittedField.fieldId, messages, sectionIndex, cb);
         });
       });
     }
@@ -736,6 +925,7 @@
     }
 
     function validateFieldInternal(submittedField, fieldDef, previousFieldValues, visible, cb) {
+
       previousFieldValues = previousFieldValues || null;
       countSubmittedValues(submittedField, function(err, numSubmittedValues) {
         if (err) {
@@ -824,10 +1014,13 @@
       }
 
       function checkValues(submittedField, fieldDefinition, previousFieldValues, cb) {
+        var sectionIndex = submittedField.sectionIndex || 0;
+
         getValidatorFunction(fieldDefinition.type, function(err, validator) {
           if (err) {
             return cb(err);
           }
+
           async.map(submittedField.fieldValues, function(fieldValue, cb) {
             if (fieldEmpty(fieldValue)) {
               return cb(undefined, null);
@@ -840,8 +1033,12 @@
                   errorMessage = null;
                 }
 
-                if (submissionRequiredFieldsMap[fieldDefinition._id]) { // set to true if at least one value
-                  submissionRequiredFieldsMap[fieldDefinition._id].submitted = true;
+                submissionRequiredFieldsMap[fieldDefinition._id] = submissionRequiredFieldsMap[fieldDefinition._id] || {sections: {}};
+                submissionRequiredFieldsMap[fieldDefinition._id].sections[sectionIndex] = submissionRequiredFieldsMap[fieldDefinition._id].sections[sectionIndex] || {};
+                var sectionValues = submissionRequiredFieldsMap[fieldDefinition._id].sections[sectionIndex];
+
+                if (sectionValues) { // set to true if at least one value
+                  sectionValues.submitted = true;
                 }
 
                 return cb(undefined, errorMessage);
@@ -1396,8 +1593,20 @@
       return cb(new Error("Should not submit section field: " + fieldDefinition.name));
     }
 
-    function rulesResult(rules, cb) {
+    /**
+     *
+     * Processing all of the rules that target a single field to check if the rule is active or not.
+     *
+     * @param {string|null} fieldId - The ID of the field being checked. If it is null then it is a page rule being checked.
+     * @param {Array} rules
+     * @param {number} sectionIndex
+     * @param {function} cb
+     */
+    function rulesResult(fieldId, rules, sectionIndex, cb) {
       var visible = true;
+
+      //Getting the section ID for the target field. The field may be in a repeating section
+      var sectionIdForTargetField = fieldSectionMapping[fieldId];
 
       // Iterate over each rule that this field is a predicate of
       async.each(rules, function(rule, cbRule) {
@@ -1410,8 +1619,24 @@
           var submissionValues = [];
           var condition;
           var testValue;
-          if (submissionFieldsMap[ruleConditionalStatement.sourceField] && submissionFieldsMap[ruleConditionalStatement.sourceField].fieldValues) {
-            submissionValues = submissionFieldsMap[ruleConditionalStatement.sourceField].fieldValues;
+
+          var sectionIdForSourceField = fieldSectionMapping[ruleConditionalStatement.sourceField];
+
+          //The fields are in the same section if and only if the sectionIds are the same OR neither are in a section
+          var sameSection = sectionIdForTargetField === sectionIdForSourceField;
+
+          var sourceFieldValues = submissionFieldsMap[ruleConditionalStatement.sourceField];
+
+          var sourceFieldValue;
+          //For repeating sections, if a source field for a rule conditional statement is outside the section of the target field, the source value has to come from the first section
+          if (!sameSection) {
+            sourceFieldValue = sourceFieldValues && sourceFieldValues[0] ? sourceFieldValues[0] : null;
+          } else {
+            sourceFieldValue = sourceFieldValues && sourceFieldValues[sectionIndex] ? sourceFieldValues[sectionIndex] : null;
+          }
+
+          if (sourceFieldValue && sourceFieldValue.fieldValues) {
+            submissionValues = sourceFieldValue.fieldValues;
             condition = ruleConditionalStatement.restriction;
             testValue = ruleConditionalStatement.sourceValue;
 
@@ -1420,6 +1645,7 @@
           }
           predicateMapQueries.push({
             "field": field,
+            "sectionIndex": sectionIndex,
             "submissionValues": submissionValues,
             "condition": condition,
             "testValue": testValue,
@@ -1443,7 +1669,7 @@
           /**
            * If any rule condition that targets the field/page hides that field/page, then the page is hidden.
            * Hiding the field/page takes precedence over any show. This will maintain consistency.
-           * E.g. if x is y then hide p1,p2 takes precedence over if x is z then show p1, p2
+           * E.g. if x is y then hide p1,p2 takes precedence over if x is y then show p1, p2
            */
           if (rulesPassed(rule.ruleConditionalOperator, predicateMapPassed, predicateMapQueries)) {
             visible = (rule.type === "show") && visible;
@@ -1465,13 +1691,30 @@
     function isPageVisible(pageId, cb) {
       init();
       if (isPageRuleSubject(pageId)) { // if the page is the target of a rule
-        return rulesResult(pageRuleSubjectMap[pageId], cb); // execute page rules
+        return rulesResult(null, pageRuleSubjectMap[pageId], 0, cb); // execute page rules
       } else {
         return cb(undefined, true); // if page is not subject of any rule then must be visible
       }
     }
 
-    function isFieldVisible(fieldId, checkContainingPage, cb) {
+    /**
+     *
+     * Checking to see if the field is visible for a section
+     *
+     * @param fieldId
+     * @param checkContainingPage
+     * @param [sectionIndex]
+     * @param cb
+     * @returns {*}
+     */
+    function isFieldVisible(fieldId, checkContainingPage, sectionIndex, cb) {
+
+      //Keeping backwards compatiblity
+      if (_.isFunction(sectionIndex)) {
+        cb = sectionIndex;
+        sectionIndex = 0;
+      }
+
       /*
        * fieldId = Id of field to check for rule predicate references
        * checkContainingPage = if true check page containing field, and return false if the page is hidden
@@ -1504,7 +1747,7 @@
           }
 
           if (isFieldRuleSubject(fieldId)) { // If the field is the subject of a rule it may have been hidden
-            return rulesResult(fieldRuleSubjectMap[fieldId], cb); // execute field rules
+            return rulesResult(fieldId, fieldRuleSubjectMap[fieldId], sectionIndex, cb); // execute field rules
           } else {
             return cb(undefined, true); // if not subject of field rules then can't be hidden
           }
@@ -1541,16 +1784,22 @@
         function(cb) {
           actions.fields = {};
           async.eachSeries(Object.keys(fieldRuleSubjectMap), function(fieldId, cb) {
-            isFieldVisible(fieldId, false, function(err, fieldVisible) {
-              if (err) {
-                return cb(err);
-              }
-              actions.fields[fieldId] = {
-                targetId: fieldId,
-                action: (fieldVisible ? "show" : "hide")
-              };
-              return cb();
-            });
+
+            var minRepeat = getSectionMinRepeat(fieldId);
+
+            async.each(_.range(minRepeat), function(sectionIndex, sectionCb) {
+              isFieldVisible(fieldId, false, sectionIndex, function(err, fieldVisible) {
+                if (err) {
+                  return cb(err);
+                }
+                actions.fields[fieldId] = {
+                  targetId: fieldId,
+                  sectionIndex: sectionIndex,
+                  action: (fieldVisible ? "show" : "hide")
+                };
+                return sectionCb();
+              });
+            }, cb);
           }, cb);
         },
         function(cb) {

--- a/lib/common/forms-rule-engine.js
+++ b/lib/common/forms-rule-engine.js
@@ -1690,7 +1690,68 @@
 
     /**
      *
-     * Processing all of the rules that target a single field to check if the rule is active or not.
+     * Checking a single rule conditional statement to determine of the rule is active.
+     *
+     * @param {string} fieldId
+     * @param {number} sectionIndex
+     * @param {Array} predicateMapQueries
+     * @param {Array} predicateMapPassed
+     * @param {object} ruleConditionalStatement
+     * @param {function} cbPredicates
+     * @returns {*}
+     */
+    function checkSingleRuleConditionalStatement(fieldId, sectionIndex, predicateMapQueries, predicateMapPassed, ruleConditionalStatement, cbPredicates) {
+      var field = fieldMap[ruleConditionalStatement.sourceField];
+      var passed = false;
+      var submissionValues = [];
+      var condition;
+      var testValue;
+
+      //Getting the section ID for the target field. The field may be in a repeating section
+      var sectionIdForTargetField = fieldSectionMapping[fieldId];
+
+      var sectionIdForSourceField = fieldSectionMapping[ruleConditionalStatement.sourceField];
+
+      //The fields are in the same section if and only if the sectionIds are the same OR neither are in a section
+      var sameSection = sectionIdForTargetField === sectionIdForSourceField;
+
+      var sourceFieldValues = submissionFieldsMap[ruleConditionalStatement.sourceField];
+
+      var sourceFieldValue;
+      //For repeating sections, if a source field for a rule conditional statement is outside the section of the target field, the source value has to come from the first section
+      if (!sameSection) {
+        sourceFieldValue = sourceFieldValues && sourceFieldValues[0] ? sourceFieldValues[0] : null;
+      } else {
+        sourceFieldValue = sourceFieldValues && sourceFieldValues[sectionIndex] ? sourceFieldValues[sectionIndex] : null;
+      }
+
+      if (sourceFieldValue && sourceFieldValue.fieldValues) {
+        submissionValues = sourceFieldValue.fieldValues;
+        condition = ruleConditionalStatement.restriction;
+        testValue = ruleConditionalStatement.sourceValue;
+
+        // Validate rule predicates on the first entry only.
+        passed = isConditionActive(field, submissionValues[0], testValue, condition);
+      }
+
+      predicateMapQueries.push({
+        "field": field,
+        "sectionIndex": sectionIndex,
+        "submissionValues": submissionValues,
+        "condition": condition,
+        "testValue": testValue,
+        "passed": passed
+      });
+
+      if (passed) {
+        predicateMapPassed.push(field);
+      }
+      return cbPredicates();
+    }
+
+    /**
+     *
+     * Processing all of the rules that target a single field/page to check if the rule is active or not.
      *
      * @param {string|null} fieldId - The ID of the field being checked. If it is null then it is a page rule being checked.
      * @param {Array} rules
@@ -1700,58 +1761,12 @@
     function rulesResult(fieldId, rules, sectionIndex, cb) {
       var visible = true;
 
-      //Getting the section ID for the target field. The field may be in a repeating section
-      var sectionIdForTargetField = fieldSectionMapping[fieldId];
-
       // Iterate over each rule that this field is a predicate of
       async.each(rules, function(rule, cbRule) {
         // For each rule, iterate over the predicate fields and evaluate the rule
         var predicateMapQueries = [];
         var predicateMapPassed = [];
-        async.each(rule.ruleConditionalStatements, function(ruleConditionalStatement, cbPredicates) {
-          var field = fieldMap[ruleConditionalStatement.sourceField];
-          var passed = false;
-          var submissionValues = [];
-          var condition;
-          var testValue;
-
-          var sectionIdForSourceField = fieldSectionMapping[ruleConditionalStatement.sourceField];
-
-          //The fields are in the same section if and only if the sectionIds are the same OR neither are in a section
-          var sameSection = sectionIdForTargetField === sectionIdForSourceField;
-
-          var sourceFieldValues = submissionFieldsMap[ruleConditionalStatement.sourceField];
-
-          var sourceFieldValue;
-          //For repeating sections, if a source field for a rule conditional statement is outside the section of the target field, the source value has to come from the first section
-          if (!sameSection) {
-            sourceFieldValue = sourceFieldValues && sourceFieldValues[0] ? sourceFieldValues[0] : null;
-          } else {
-            sourceFieldValue = sourceFieldValues && sourceFieldValues[sectionIndex] ? sourceFieldValues[sectionIndex] : null;
-          }
-
-          if (sourceFieldValue && sourceFieldValue.fieldValues) {
-            submissionValues = sourceFieldValue.fieldValues;
-            condition = ruleConditionalStatement.restriction;
-            testValue = ruleConditionalStatement.sourceValue;
-
-            // Validate rule predicates on the first entry only.
-            passed = isConditionActive(field, submissionValues[0], testValue, condition);
-          }
-          predicateMapQueries.push({
-            "field": field,
-            "sectionIndex": sectionIndex,
-            "submissionValues": submissionValues,
-            "condition": condition,
-            "testValue": testValue,
-            "passed": passed
-          });
-
-          if (passed) {
-            predicateMapPassed.push(field);
-          }
-          return cbPredicates();
-        }, function(err) {
+        async.each(rule.ruleConditionalStatements, async.apply(checkSingleRuleConditionalStatement, fieldId, sectionIndex, predicateMapQueries, predicateMapPassed), function(err) {
           if (err) {
             cbRule(err);
           }
@@ -1775,11 +1790,7 @@
           return cbRule();
         });
       }, function(err) {
-        if (err) {
-          return cb(err);
-        }
-
-        return cb(undefined, visible);
+        return cb(err, visible);
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {

--- a/test/Fixtures/repeatingSectionRulesForm.json
+++ b/test/Fixtures/repeatingSectionRulesForm.json
@@ -1,0 +1,76 @@
+{
+  "name": "Repeating Sections Form",
+  "description": "This form has repeating sections.",
+  "lastUpdated": "2013-10-16 06:13:52",
+  "pages": [
+    {
+      "_id": "page1id",
+      "fields": [
+        {
+          "_id": "numberfieldoutsidesection",
+          "fieldOptions": {},
+          "name": "Number Field Outside Section",
+          "required": false,
+          "type": "number"
+        },
+        {
+          "_id": "sectionbreakfield1",
+          "fieldOptions": {
+            "definition":{
+              "maxRepeat":3,
+              "minRepeat":2
+            }
+          },
+          "name": "Section Break 1",
+          "type": "sectionBreak",
+          "repeating": true
+        },
+        {
+          "_id": "numberfield1",
+          "fieldOptions": {},
+          "name": "Number Field 2",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "_id": "textareafield1",
+          "fieldOptions": {},
+          "name": "Text Field Area 1",
+          "required": true,
+          "type": "textarea"
+        },
+        {
+          "_id": "textareafield2",
+          "fieldOptions": {},
+          "name": "Text Field Area 2",
+          "required": false,
+          "type": "textarea"
+        }
+      ]
+    }
+  ],
+  "fieldRules": [{
+    "_id": "53bfaf11a33bcfd2434e0489",
+    "targetField": "numberfield1",
+    "type": "hide",
+    "ruleConditionalStatements": [{
+      "sourceField": "textareafield1",
+      "restriction": "is",
+      "sourceValue": "hide"
+    }],
+    "ruleConditionalOperator": "or",
+    "relationType": "and"
+  }, {
+    "_id": "53bfaf11a33bcfd2434e0490",
+    "targetField": "numberfield1",
+    "type": "hide",
+    "ruleConditionalStatements": [{
+      "sourceField": "numberfieldoutsidesection",
+      "restriction": "is equal to",
+      "sourceValue": 2
+    }],
+    "ruleConditionalOperator": "or",
+    "relationType": "and"
+  }],
+  "pageRules": []
+}

--- a/test/Fixtures/repeatingSectionRulesForm.json
+++ b/test/Fixtures/repeatingSectionRulesForm.json
@@ -23,7 +23,8 @@
           },
           "name": "Section Break 1",
           "type": "sectionBreak",
-          "repeating": true
+          "repeating": true,
+          "required": true
         },
         {
           "_id": "numberfield1",

--- a/test/Fixtures/repeatingSectionsForm.json
+++ b/test/Fixtures/repeatingSectionsForm.json
@@ -1,0 +1,47 @@
+{
+  "name": "Repeating Sections Form",
+  "description": "This form has repeating sections.",
+  "lastUpdated": "2013-10-16 06:13:52",
+  "pages": [
+    {
+      "_id": "page1id",
+      "fields": [
+        {
+          "_id": "sectionbreakfield1",
+          "fieldOptions": {
+            "definition":{
+              "maxRepeat":3,
+              "minRepeat":2
+            }
+          },
+          "name": "Section Break 1",
+          "type": "sectionBreak",
+          "repeating": true
+        },
+        {
+          "_id": "numberfield1",
+          "fieldOptions": {},
+          "name": "Text Field 2",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "_id": "textareafield1",
+          "fieldOptions": {},
+          "name": "Text Field Area 1",
+          "required": true,
+          "type": "textarea"
+        },
+        {
+          "_id": "textareafield2",
+          "fieldOptions": {},
+          "name": "Text Field Area 2",
+          "required": false,
+          "type": "textarea"
+        }
+      ]
+    }
+  ],
+  "fieldRules": [],
+  "pageRules": []
+}

--- a/test/Fixtures/repeatingSectionsForm.json
+++ b/test/Fixtures/repeatingSectionsForm.json
@@ -16,7 +16,8 @@
           },
           "name": "Section Break 1",
           "type": "sectionBreak",
-          "repeating": true
+          "repeating": true,
+          "required": true
         },
         {
           "_id": "numberfield1",

--- a/test/unit/rulesEngine/test_repeating_sections.js
+++ b/test/unit/rulesEngine/test_repeating_sections.js
@@ -1,0 +1,243 @@
+var assert = require('assert');
+var util = require("util");
+var _ = require('underscore');
+var formsRulesEngine = require('../../../lib/common/forms-rule-engine.js');
+
+var repeatingSectionsForm = require('../../Fixtures/repeatingSectionsForm.json');
+var repeatingSectionsRuleForm = require('../../Fixtures/repeatingSectionRulesForm.json');
+var getBaseSubmission = require('../../Fixtures/baseSubmission');
+
+var TEXT_AREA_FIELD_1_ID = "textareafield1";
+var SECTION_FIELD_ID = "sectionbreakfield1";
+var NUMBER_FIELD_ID = "numberfield1";
+
+var submissionFields = {
+  number: {
+    fieldId: NUMBER_FIELD_ID,
+    fieldValues: [12]
+  },
+  textarea: {
+    fieldId: TEXT_AREA_FIELD_1_ID,
+    fieldValues: ["AREA VAL 1"]
+  },
+  text: {
+    fieldId: "textfield",
+    fieldValues: ["textvalue1"]
+  }
+};
+
+/**
+ *
+ * Getting an example field value entry.
+ *
+ * @param type
+ * @param sectionIndex
+ * @returns {*}
+ */
+function getSubmissionField(type, sectionIndex) {
+  var sectionValue = _.clone(submissionFields[type]);
+  sectionValue.sectionIndex = sectionIndex;
+  return sectionValue;
+}
+
+
+describe("Repeating Sections", function() {
+
+  var repeatingSectionsFormValidator = formsRulesEngine(repeatingSectionsForm);
+
+  it('should validate that multiple repeating section values are passed', function(done) {
+    var submission = getBaseSubmission();
+
+    submission.formFields = [
+      //values for section 1 repeat 1
+      getSubmissionField('number', 0),
+      getSubmissionField('textarea', 0),
+
+      //values for section 1 repeat 2
+      getSubmissionField('number', 1),
+      getSubmissionField('textarea', 1)];
+
+    repeatingSectionsFormValidator.validateForm(submission, function(err, results) {
+      assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+      assert.ok(results.validation.valid, "expected valid result: " + util.inspect(results.validation));
+      done();
+    });
+  });
+
+  it('should default to section index 0 if not supplied', function(done) {
+    var submission = getBaseSubmission();
+
+    submission.formFields = [
+      //values for section 1 repeat 1
+      getSubmissionField('number', undefined),
+      getSubmissionField('textarea', undefined),
+
+      //values for section 1 repeat 2
+      getSubmissionField('number', 1),
+      getSubmissionField('textarea', 1)];
+
+    repeatingSectionsFormValidator.validateForm(submission, function(err, results) {
+      assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+      assert.ok(results.validation.valid, "expected valid result: " + util.inspect(results.validation));
+      done();
+    });
+  });
+
+  it('should return an error if a repeating section value is missing', function(done) {
+    var submission = getBaseSubmission();
+
+    submission.formFields = [
+      //values for section 1 repeat 1
+      getSubmissionField('number', 0),
+      getSubmissionField('textarea', 0),
+
+      //values for section 1 repeat 2 - missing field
+      getSubmissionField('number', 1)];
+
+    repeatingSectionsFormValidator.validateForm(submission, function(err, results) {
+
+      assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+      assert.ok(!results.validation.valid, "unexpected valid result: " + util.inspect(results.validation));
+
+      assert.ok(results.validation[TEXT_AREA_FIELD_1_ID], 'should be error for missing required field - ' + util.inspect(results.validation));
+
+      var sectionErrors = results.validation[TEXT_AREA_FIELD_1_ID].sections;
+
+      assert.ok(!sectionErrors[1].valid, 'missing required field in section 2 should be marked as invalid');
+      assert.equal(1, sectionErrors[1].sectionIndex);
+      assert.equal(sectionErrors[1].fieldErrorMessage.length, 1, 'should be 1 error message for missing required field - was: ' + util.inspect(sectionErrors[1].fieldErrorMessage));
+
+      done();
+    });
+  });
+
+  it('should check for too many sections passed', function(done) {
+    var submission = getBaseSubmission();
+
+    submission.formFields = [
+      //values for section 1 repeat 1
+      getSubmissionField('number', 0),
+      getSubmissionField('textarea', 0),
+
+      //values for section 1 repeat 2
+      getSubmissionField('number', 1),
+      getSubmissionField('textarea', 1),
+
+      //values for section 1 repeat 3
+      getSubmissionField('number', 2),
+      getSubmissionField('textarea', 2),
+
+      //values for section 1 repeat 4 - Too Many
+      getSubmissionField('number', 3),
+      getSubmissionField('textarea', 3)];
+
+    repeatingSectionsFormValidator.validateForm(submission, function(err, results) {
+      assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+      assert.ok(!results.validation.valid, "unexpected valid result: " + util.inspect(results.validation));
+
+      var sectionResults = results.validation[SECTION_FIELD_ID].sections;
+
+      assert.ok(results.validation[SECTION_FIELD_ID], 'should be error for missing required field - ' + util.inspect(results.validation));
+      assert.ok(!sectionResults[3].valid, 'missing required field in section 2 should be marked as invalid');
+      assert.equal(3, sectionResults[3].sectionIndex);
+      assert.equal(sectionResults[3].fieldErrorMessage[0], "Expected a maximum of 3 sections but got 4.");
+
+      done();
+    });
+
+  });
+
+
+  describe("Rules Within A Repeating Section", function() {
+
+    var repeatingSectionsFormRuleValidator = formsRulesEngine(repeatingSectionsRuleForm);
+
+    it('should only hide the field in a single section', function(done) {
+      var submission = getBaseSubmission();
+
+      var textAreaFieldEntry = getSubmissionField('textarea', 0);
+      textAreaFieldEntry.fieldValues = ['hide'];
+
+      submission.formFields = [
+        //values for section 1 repeat 1 - The `show` value in the textarea field should make the number field required
+        //in this section
+        getSubmissionField('number', 0),
+        textAreaFieldEntry,
+
+        //values for section 1 repeat 2 - The default value in the textarea field should make the number field required for this section
+        getSubmissionField('textarea', 1)
+      ];
+
+      repeatingSectionsFormRuleValidator.validateForm(submission, function(err, results) {
+        assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+        assert.ok(!results.validation.valid, "unexpected valid result: " + util.inspect(results.validation));
+
+        assert.ok(results.validation[NUMBER_FIELD_ID], 'should be error for missing required field - ' + util.inspect(results.validation));
+        assert.ok(!results.validation[NUMBER_FIELD_ID].valid, 'missing required field in section 2 should be marked as invalid');
+        assert.equal(1, results.validation[NUMBER_FIELD_ID].sections[1].sectionIndex);
+        assert.equal(results.validation[NUMBER_FIELD_ID].sections[1].fieldErrorMessage[0], "Required Field Not Submitted");
+
+        assert.equal(undefined, results.validation[NUMBER_FIELD_ID].sections[0], "Expected no validation error for the first section. The rule should have hidden the number field");
+        done();
+      });
+    });
+
+    it('should validate a single field in multiple sections', function(done) {
+      var submission = getBaseSubmission();
+
+
+      submission.formFields = [
+        //values for section 1 repeat 1 - Missing the number field
+        getSubmissionField('textarea', 0),
+
+        //values for section 1 repeat 2 - Missing the number field
+        getSubmissionField('textarea', 1)
+      ];
+
+      repeatingSectionsFormRuleValidator.validateForm(submission, function(err, results) {
+        console.log("** RESULT", results.validation[NUMBER_FIELD_ID].sections);
+        assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+        assert.ok(!results.validation.valid, "unexpected valid result: " + util.inspect(results.validation));
+
+        assert.ok(results.validation[NUMBER_FIELD_ID], 'should be error for missing required field - ' + util.inspect(results.validation));
+        assert.ok(!results.validation[NUMBER_FIELD_ID].valid, 'missing required field in section 2 should be marked as invalid');
+
+        //Expecting the first entry to be the invalid number field in section repeat 0
+        assert.equal(0, results.validation[NUMBER_FIELD_ID].sections[0].sectionIndex);
+        assert.equal("Required Field Not Submitted", results.validation[NUMBER_FIELD_ID].sections[0].fieldErrorMessage[0]);
+
+        //Expecting the first entry to be the invalid number field in section repeat 1
+        assert.equal(1, results.validation[NUMBER_FIELD_ID].sections[1].sectionIndex);
+        assert.equal("Required Field Not Submitted", results.validation[NUMBER_FIELD_ID].sections[1].fieldErrorMessage[0]);
+
+        done();
+      });
+    });
+
+    it('should hide a field in a repeating section when targeting from outside the repeating section', function(done) {
+      var submission = getBaseSubmission();
+
+      submission.formFields = [
+        //Setting the 2 value to trigger the field rule that triggers hiding the number fields
+        {
+          fieldId: 'numberfieldoutsidesection',
+          fieldValues: [2]
+        },
+        //values for section 1 repeat 1 - Missing the number field
+        getSubmissionField('textarea', 0),
+
+        //values for section 1 repeat 2 - Missing the number field
+        getSubmissionField('textarea', 1)
+      ];
+
+      repeatingSectionsFormRuleValidator.validateForm(submission, function(err, results) {
+        assert.ok(!err, 'unexpected error from validateForm: ' + util.inspect(err));
+
+        //If the number fields are being hidden, then they shouldn't be required.
+        assert.ok(results.validation.valid, "Expected valid result: " + util.inspect(results.validation));
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

To be able to handle fields that can be in repeating sections, the rules engine needs to be upgraded to:

- Handle values submitted with a `sectionIndex`
- Maintain backwards compatibility for values submitted without a `sectionIndex`

# Changes

Upgraded the rules engine to index  the submitted fields by the sectionId (defaults to 0)
Added the `sections` field to the validation object 

```
{
   "validation":{
      "validatedfieldid":{
         "fieldId":"validatedfieldid",
         "valid":false,
          "sections": {
             "0": {
                "fieldId":"validatedfieldid",
                "valid":false,
                "errorMessages":[
                    "length should be 3 to 5",
                     "should not contain dammit",
                    "should repeat at least 2 times"
                ]
             },
             "1": {
                ....
             }
         }
      },
      "fieldId1":{
         ...
      }
   }
}
```
