### PR TITLE
[task]: RHMAP-20284 - Update CI process to use supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_script:
   - mongo admin --eval 'db.createUser({user:"admin",pwd:"admin",roles:[{role:"userAdminAnyDatabase",db:"admin"}]});'
 script:
   - grunt
+  - grunt coverallsio

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: node_js
 node_js:
+  - '4'
   - '6'
+  - '8'
 sudo: false
+before_install:
+  - npm install -g grunt-cli
+env:
+  - MONGODB_VERSION=2.4
+  - MONGODB_VERSION=3.2
 services:
   - mongodb
 before_script:
   - mongo admin --eval 'db.createUser({user:"admin",pwd:"admin",roles:[{role:"userAdminAnyDatabase",db:"admin"}]});'
 script:
   - grunt
-  - grunt coverallsio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased - Wed May 2, 2018
+### Change
+- Update dev dependencies to allow run the CI process with NodeJS 8.
+- Updating project to make clear the min version required to run it
+- Add CHANGELOG file
+- Update CI process to use supported versions
+- Remove sonar file since it is not so long used
+
+
+ 
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,8 @@ module.exports = function(grunt) {
     accept: ['node ./test/setup_mongo_node.js', '<%= _accept_runner %> <%= _accept_args %>'],
     accept_cover: ['node ./test/setup_mongo_node.js', 'istanbul cover --dir cov-accept <%= _accept_runner %> -- <%= _accept_args %>'],
 
+    integrate:['_mocha ./test/integrate'],
+    integrate_cover:['istanbul cover --dir cov-integrate _mocha ./test/integrate'],
     coveralls: {
       target: {
         src: 'coverage/lcov.info'

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "sinon-as-promised": "^4.0.2"
   },
   "engines": {
-    "node": "4.4"
+    "node": ">=6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "yauzl": "2.4.1"
   },
   "devDependencies": {
-    "bunyan": "^1.5.1",
-    "cli-color": "^1.1.0",
+    "bunyan": "^1.8.12",
+    "cli-color": "^1.2.0",
     "eslint": "^2.7.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "5.0.0",
@@ -52,14 +52,13 @@
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-coveralls": "^1.0.1",
     "grunt-fh-build": "2.0.0",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.2.5",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.1.1",
     "nock": "^8.0.0",
     "proxyquire": "^1.7.4",
     "recursive-readdir": "^2.0.0",
-    "sinon": "^1.17.3",
-    "sinon-as-promised": "4.0.2",
-    "turbo-test-runner": "0.3.3"
+    "sinon": "^1.17.7",
+    "sinon-as-promised": "^4.0.2"
   },
   "engines": {
     "node": "4.4"


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20284

## WHAT
* Update to use NodeJS version 6 and 8 as follows.

```
node_js:
  - '6'
  - '8'
```
* Update to use the support MongoDB versions. 
* Update the version in the engine to make clear the min required version to run it. 
* Remove `grunt coverallsio` since it makes the CI process to slow and is no longer used. Also, it is facing some issue when trying to build in the MongoDB 3.2 and the default npm from NodeJS 6.
 
## WHY
Use in the CI the currently supported versions.

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 