### PR TITLE
[fix] - regards the PR #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.16.7 - Fri May 4, 2018
+### Fix
+- Fix undefined properties called when a Data Sources is checked
+
 ## Unreleased - Wed May 2, 2018
 ### Change
 - Update dev dependencies to allow run the CI process with NodeJS 8.
@@ -12,3 +16,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update CI process to use supported versions
 - Remove sonar file since it is not so long used
 - Added checking for undefined elements of the datasources array
+

--- a/lib/impl/dataSources/updateCache.js
+++ b/lib/impl/dataSources/updateCache.js
@@ -24,7 +24,6 @@ function updateValidAndInvalidDataSources(dataSourcesToSplit, currentInvalidData
     if (dataSourceUpdateData) {
       return !dataSourceUpdateData.error;
     }
-    return true;
   });
 
   var validDataSources = validInvalid[0];


### PR DESCRIPTION
## WHAT:

* Add changelog info which is missing
* Remove the return true added 

## WHY

The return true is a new behavior and is not the goal of the PR #46. The goal of this previous PR is solve the issue `Cannot read property 'error' of undefined` of the following code.

```
var validInvalid = _.partition(dataSourcesToSplit, function(dataSourceUpdateData) {
    return !dataSourceUpdateData.error;
  });
```

The solution in the PR #46 is:

````
if ( dataSourceUpdateData ){
    return !dataSourceUpdateData.error;
} 
return true;
````

However, to solve the issue we need just to check if dataSourceUpdateData is defined or not and return the true, the true returned may create a new behavior which is not the achivement here.  Probably, has another implementation to daling with this scenario. 

