### PR TITLE
fix(Unable to edit submissions): RHMAP-20490: Hidden fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - Wed May 2, 2018
+## Release 
+
+## 1.16.8 - Thu May 17, 2018
+### Fix
+- Unable to edit submissions with hidden fields
+
 ### Change
 - Update dev dependencies to allow run the CI process with NodeJS 8.
 - Updating project to make clear the min version required to run it

--- a/lib/impl/submitFormDataFunctions/pruneHiddenFieldData.js
+++ b/lib/impl/submitFormDataFunctions/pruneHiddenFieldData.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var rulesEngine = require('../../common/forms-rule-engine');
-
 /**
  *
  * Getting the IDs of all fields that have been hidden.
@@ -10,13 +9,10 @@ var rulesEngine = require('../../common/forms-rule-engine');
  * @returns {Array}  - Array of field IDs hidden by the rules.
  */
 function getHiddenFieldIDs(actions, formDefinition) {
-
   var ruleTypes = ["fields", "pages"];
-
   //For page and field rule actions, find the hidden fields.
   var allHiddenFieldIds = _.map(ruleTypes, function(ruleType) {
     var fieldIds = [];
-
     var hidden = _.map(actions[ruleType] || {}, function(ruleAction, fieldOrPageId) {
       if (ruleAction.action === 'hide') {
         return fieldOrPageId;
@@ -24,69 +20,61 @@ function getHiddenFieldIDs(actions, formDefinition) {
         return null;
       }
     });
-
     //If it is a hidden page, need to check for all fields that are in the page.
     //All of these fields are considered hidden.
     if (ruleType === 'pages') {
       fieldIds = _.map(hidden, function(pageId) {
         var pageDefinition = _.findWhere(formDefinition.pages, {_id: pageId}) || {};
-
         return _.pluck(pageDefinition.fields || [], "_id");
       });
     } else {
       fieldIds = hidden;
     }
-
     return _.compact(_.flatten(fieldIds));
   });
-
   return _.flatten(allHiddenFieldIds);
 }
 
 /**
- *
- * Function for removing any values from a submisson that in hidden fields.
+ * Function for save empty data for any values from a submisson that in hidden fields.
  * @param {object} formDefinition
  * @param {object} submissionData
  * @param {function} cb - Callback function
  * @returns {*}
  */
 module.exports = function pruneHiddenFieldData(formDefinition, submissionData, cb) {
-
   var formRulesEngine = rulesEngine(formDefinition);
-
   //Checking if the fieldId was populated with a Field model
   submissionData.formFields = _.map(submissionData.formFields, function(formField) {
     if (formField.fieldId && formField.fieldId._id) {
       formField.fieldId = formField.fieldId._id;
     }
-
     //Converting to a string if it was an ObjectID for comparision.
     formField.fieldId = formField.fieldId.toString();
-
     return formField;
   });
-
+  //Checking if the formField is a hiddenField
+  function isHidden(formField, allHiddenFieldIds) {
+    return formField.fieldId && _.find(allHiddenFieldIds, function(hiddenFieldId) {
+      if (hiddenFieldId.indexOf('_') < 0) {
+        return hiddenFieldId.toString() === formField.fieldId.toString();
+      } else {
+        return hiddenFieldId.toString() === (formField.fieldId.toString() + '_' + formField.sectionIndex);
+      }
+    });
+  }
   formRulesEngine.checkRules(submissionData, function(err, ruleState) {
     if (err) {
       return cb(err);
     }
-
     var allHiddenFieldIds = getHiddenFieldIDs(ruleState.actions, formDefinition);
-
-    //Don't save data for fields that have been hidden.
-    submissionData.formFields = _.filter(submissionData.formFields, function(formField) {
+    //Save empty data for fields which are hidden.
+    _.each(submissionData.formFields, function(formField) {
       formField = formField || {};
-
-      return formField.fieldId && !_.find(allHiddenFieldIds, function(hiddenFieldId) {
-        if (hiddenFieldId.indexOf('_') < 0) {
-          return hiddenFieldId.toString() === formField.fieldId.toString();
-        } else {
-          return hiddenFieldId.toString() === (formField.fieldId.toString() + '_' + formField.sectionIndex);
-        }
-      });
+      if ( isHidden(formField, allHiddenFieldIds) ) {
+        formField.fieldValues = [];
+      }
     });
-
     return cb(undefined, submissionData);
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {

--- a/test/unit/submitFormDataFunctions/test_pruneHiddenFieldData.js
+++ b/test/unit/submitFormDataFunctions/test_pruneHiddenFieldData.js
@@ -3,7 +3,7 @@ var pruneHiddenFieldData = require('../../../lib/impl/submitFormDataFunctions/pr
 var ObjectId = require('mongoose').Types.ObjectId;
 var assert = require('assert');
 
-describe("Submissions values should be removed from hidden fields", function() {
+describe("Submissions values should have empty hidden fields", function() {
 
   var testHidingFieldsForm = {
     "_id":"582dbc9009ce8d9c6e63f532",
@@ -117,12 +117,12 @@ describe("Submissions values should be removed from hidden fields", function() {
   };
 
 
-  describe("Hiding a field should remove a field value", function() {
+  describe("Hiding a field should have empty value", function() {
     var textFieldId = "582dbce709ce8d9c6e63f533";
+    var numberFieldId = "582dbce709ce8d9c6e63f534";
     /**
      * Checking the pruned results for removed fields.
-     *
-     * Checking that field data that should be removed has been.
+     * Checking that field data that is empty.
      *
      * @param err
      * @param prunedSubmission
@@ -130,11 +130,11 @@ describe("Submissions values should be removed from hidden fields", function() {
     function checkResults(err, prunedSubmission) {
       assert.ok(!err, "Expected no error when pruning hidden fields", err);
       var formFields = prunedSubmission.formFields;
-
-      //There should only be one entry for the text field.
-      assert.equal(1, formFields.length, "Expected only one value entry");
-      assert.equal(textFieldId, formFields[0].fieldId);
-      assert.equal("hidenumber", formFields[0].fieldValues[0]);
+      assert.equal(2, formFields.length, "Expected only 2 entries");
+      assert.equal(textFieldId, formFields[0].fieldId, "Expected text field ID");
+      assert.equal(numberFieldId, formFields[1].fieldId, "Expected number field ID");
+      assert.equal("hidenumber", formFields[0].fieldValues[0], "Expected a value in the text field not hidden");
+      assert.equal(undefined, formFields[1].fieldValues[0],"Expected empty value for the hidden field");
     }
 
     /**
@@ -194,7 +194,7 @@ describe("Submissions values should be removed from hidden fields", function() {
 
   });
 
-  it("Hiding a Page should remove values in all fields in that page", function(done) {
+  it("Hiding a Page should have empty values in all fields in that page", function(done) {
 
     var submission = getBaseSubmission();
 
@@ -222,11 +222,16 @@ describe("Submissions values should be removed from hidden fields", function() {
     pruneHiddenFieldData(testHidingFieldsForm, submission, function(err, prunedSubmission) {
       assert.ok(!err, "Expected no error when pruning hidden fields", err);
       var formFields = prunedSubmission.formFields;
-
-      //There should only be one entry for the text field.
-      assert.equal(1, formFields.length, "Expected only one value entry");
-      assert.equal("582dbce709ce8d9c6e63f533", formFields[0].fieldId);
-      assert.equal("hidepage", formFields[0].fieldValues[0]);
+      var hidePageFieldId = "582dbce709ce8d9c6e63f533";
+      var hiddenFieldId1 = "582dbce709ce8d9c6e63f536";
+      var hiddenFieldId2 = "582dbce709ce8d9c6e63f537";
+      assert.equal(3, formFields.length, "Expected only 3 entries");
+      assert.equal(hidePageFieldId, formFields[0].fieldId, "Expected hide page field ID");
+      assert.equal(hiddenFieldId1, formFields[1].fieldId, "Expected hidden field ID");
+      assert.equal(hiddenFieldId2, formFields[2].fieldId, "Expected hidden field ID");
+      assert.equal("hidepage", formFields[0].fieldValues[0], "Expected a value in the text field not hidden");
+      assert.equal(undefined, formFields[1].fieldValues[0],"Expected empty value for the hidden field");
+      assert.equal(undefined, formFields[2].fieldValues[0],"Expected empty value for the hidden field");
       done();
     });
   });


### PR DESCRIPTION
## JIRA:
https://issues.jboss.org/browse/RHMAP-20490

## WHAT:
* Unable to update submission in RHMAP studio when has hidden fields
* Submissions are not being displayed in the correct column when the form has hidden fields. Following an image with an example, where the number is the third field into the form and it is showing in the second column instead of the third one. 
<img width="1298" alt="screen shot 2018-05-17 at 21 25 49" src="https://user-images.githubusercontent.com/7708031/40202183-14bc7598-5a19-11e8-893f-29ba21431387.png">
 
## WHY:
The hidden fields were not been saved which result in don't allow updated them as don't show values in the correct position in the `Drag & Drop Apps >> Forms Submissions` 

## HOW:
Save the hidden fields with empty values.

## STEPS TO TEST

### FH-FORMS:
The tests are covering the changes made in the `fh-forms` as shows the following image. In this way, check if the CI to merge the PR was finalized with success. 

 <img width="542" alt="screen shot 2018-05-17 at 21 15 24" src="https://user-images.githubusercontent.com/7708031/40201698-bf9f958c-5a17-11e8-8616-0968f6dbe043.png">

<img width="616" alt="screen shot 2018-05-17 at 22 20 43" src="https://user-images.githubusercontent.com/7708031/40204527-c918aaaa-5a20-11e8-84e6-2ce03fd7151f.png">

## RHMAP studio:
To check it in RHMAP is required to ensure that this source/PR will be used by RHMAP when the submission is generated.  The components/projects affected are: `appforms-project-client`, `Appforms-Template-v3`, `fh-js-sdk`, `fh-mbaas`, `fhcap`, `fh-templates-app`. 

### Steps to check it in the studio.

1. Go to the RHMAP domain 
2. Create a form with; 1 text field + 1 checkbox + 1 number field
3. Don't make the text field and the checkbox mandatory
4. Add a role for this form for the checkbox appears just if the text field has some value
5. Save and Deploy form
6. Link the form with a form project
7. Go to the cloud application of this form and ensure that you are using this version of the fh-forms via the fh-mbaas-api. Save and deploy it.
8. Go to the Preview/editor and create a new submission without value for the checkbox
9. Go to `Drag & Drop Apps >> Forms Submissions` and check if the number will appears correctly in the third field and try to update a submission by adding the value for the checkbox. Following an image as an example. 

<img width="602" alt="screen shot 2018-05-17 at 22 22 49" src="https://user-images.githubusercontent.com/7708031/40204578-f185752c-5a20-11e8-942b-c81975b6a97b.png">


