### PR TITLE
Small correction of the PR 51

### DIFF
--- a/lib/impl/submitFormDataFunctions/pruneHiddenFieldData.js
+++ b/lib/impl/submitFormDataFunctions/pruneHiddenFieldData.js
@@ -72,7 +72,7 @@ module.exports = function pruneHiddenFieldData(formDefinition, submissionData, c
     _.each(submissionData.formFields, function(formField) {
       formField = formField || {};
       if ( isHidden(formField, allHiddenFieldIds) ) {
-        formField.fieldValues = [];
+        formField.fieldValues = [""];
       }
     });
     return cb(undefined, submissionData);

--- a/test/unit/submitFormDataFunctions/test_pruneHiddenFieldData.js
+++ b/test/unit/submitFormDataFunctions/test_pruneHiddenFieldData.js
@@ -134,7 +134,7 @@ describe("Submissions values should have empty hidden fields", function() {
       assert.equal(textFieldId, formFields[0].fieldId, "Expected text field ID");
       assert.equal(numberFieldId, formFields[1].fieldId, "Expected number field ID");
       assert.equal("hidenumber", formFields[0].fieldValues[0], "Expected a value in the text field not hidden");
-      assert.equal(undefined, formFields[1].fieldValues[0],"Expected empty value for the hidden field");
+      assert.equal("", formFields[1].fieldValues[0],"Expected empty value for the hidden field");
     }
 
     /**
@@ -230,8 +230,8 @@ describe("Submissions values should have empty hidden fields", function() {
       assert.equal(hiddenFieldId1, formFields[1].fieldId, "Expected hidden field ID");
       assert.equal(hiddenFieldId2, formFields[2].fieldId, "Expected hidden field ID");
       assert.equal("hidepage", formFields[0].fieldValues[0], "Expected a value in the text field not hidden");
-      assert.equal(undefined, formFields[1].fieldValues[0],"Expected empty value for the hidden field");
-      assert.equal(undefined, formFields[2].fieldValues[0],"Expected empty value for the hidden field");
+      assert.equal("", formFields[1].fieldValues[0],"Expected empty value for the hidden field");
+      assert.equal("", formFields[2].fieldValues[0],"Expected empty value for the hidden field");
       done();
     });
   });


### PR DESCRIPTION
## JIRA:
https://issues.jboss.org/browse/RHMAP-20490

## WHAT:
Correction of the PR: https://github.com/feedhenry/fh-forms/pull/51

## WHY:
The fh-mbaas will not work with undefined. 

## HOW:
Instead of save the value as undefined it was changed to save an empty string. 

## STEPS TO TEST: 

* The description is the PR: https://github.com/feedhenry/fh-forms/pull/51
* According to @witmicko is not required upgrade the fh-forms in the SDK and client app form, which will be great since in this way for the user get the fix don't need to use a new version of the client app, create a new project and liked it with the form. ( just fh-mbaas and fh-supercore) 
* I am working on in verifying it locally integrated with RHMAP. 
* The JIRA [RHMAP-11349](https://issues.jboss.org/browse/RHMAP-11349) where this implementation was added contains PRs for the SDK and client application, also if we check the JSON sent by the client app it is without the hidden fields which make me think that these points need to use the new version of fh-forms 1.16.8. In this way, it needs to be checked If change the fh-mbaas only did not reflect this change then the projects `Appforms-Template-v3`and `appforms-project-client` must be upgraded. 

P.S: The the PR: https://github.com/feedhenry/fh-forms/pull/51 was merged in order to try to help with the tests/verifications since was reviewed yet, however, @witmicko show me that we can create a dev tag which is made to perform these integrated tests `1.16.8-alpha.2`




