### PR TITLE
fix:broken file links in appforms submissions pdf files:RHMAP-20655

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.16.8] - 2018-06-20
+### Changed
+### Fixed
+- Fixing broken link in submission pdf for files
+
 ## [1.16.8] - 2018-06-05
 ### Changed
 - Update dev dependencies to allow run the CI process with NodeJS 8.

--- a/lib/templates/helpers.js
+++ b/lib/templates/helpers.js
@@ -99,6 +99,9 @@ Handlebars.registerHelper("createFormField", function(options, editMode) {
       data.groupid = val.groupId;
       data.hash = val.hashName;
       data.fileName = val.fileName;
+      if (typeof(data.url) === "string") {
+        data.url = data.url.replace('http://', 'https://');
+      }
     }
     options.data.push(data);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20655


# What
The file link in appforms submissions pdf gives the HTTP version of the link to download file
![image](https://user-images.githubusercontent.com/16667688/41161360-7fd71ece-6b2a-11e8-808e-dc6b8d6ef17c.png)


# Why
Need this to be HTTPS as we get access denied on the HTTP version of the link



# How



# Verification Steps

- Create a forms app
- Deploy the cloud app
- Create a form with a file upload option
- Deploy the form to the same environment as the cloud app
- Add the form to the Forms app
- Submit form via the Cordova app
- check submissions
- Click on the download button for pdf
- Try to click on file link in pdf


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 