### PR TITLE
RHMAP-21636 - Upgrade request and mongodb lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.16.10] - 2018-06-20
+### Changed
+- Upgrade request and mongodb libs
+
+## [Released]]
+
 ## [1.16.8] - 2018-06-20
 ### Changed
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mkdirp": "^0.5.1",
     "mmmagic": "^0.4.1",
     "moment": "2.19.3",
-    "mongodb": "2.1.18",
+    "mongodb": "2.2.35",
     "mongodb-uri": "0.9.7",
     "mongoose": "4.11.14",
     "mongoose-paginate": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-forms",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "description": "Cloud Forms API for form submission",
   "main": "fhforms.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mongoose": "4.11.14",
     "mongoose-paginate": "5.0.3",
     "phantom": "4.0.12",
-    "request": "2.83.0",
+    "request": "2.88.0",
     "underscore": "1.8.0",
     "yauzl": "2.4.1"
   },


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21636


# What
* Upgrade request lib to 2.88.0
* Upgrade mongodb lib to 2.2.35

# Why
Solve CEVs

# How
* `npm install --save --save-exact mongodb@2.2.35`
* `npm install --save --save-exact request@2.88.0`

# Verification Steps
Since the both did not have breakages and will be checked/used by the test then the CI process is covering this change. So, it is required to check if finish with success for all CIs which will test it in the MongoDB 2.4 and 3.2 which is the used ones. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 